### PR TITLE
Fix support for l2tpv3 over ip

### DIFF
--- a/templates/interfaces/l2tpv3/node.def
+++ b/templates/interfaces/l2tpv3/node.def
@@ -26,6 +26,9 @@ commit:expression: $VAR(./peer-session-id/) != "" ;                    \
 begin:
   [ -d /sys/module/l2tp_eth ] || sudo modprobe l2tp_eth
   [ -d /sys/module/l2tp_netlink ] || sudo modprobe l2tp_netlink
+  if [ "$VAR(./encap/@)" = "ip" ] && [ ! -d /sys/module/l2tp_ip ] ; then
+    sudo modprobe l2tp_ip
+  fi
 
 create:
   for i in `seq 1 $VAR(./wait/@)`

--- a/templates/interfaces/l2tpv3/node.tag/encap/node.def
+++ b/templates/interfaces/l2tpv3/node.tag/encap/node.def
@@ -1,7 +1,7 @@
-help: Encryption algorithm
+help: Encapsulation type
 type: txt
 default: "udp"
 syntax:expression: $VAR(@) in "ip", "udp"; "must be ip, or udp"
 
-val_help: udp; udp encryption (default)
-val_help: ip; ip encryption
+val_help: udp; udp encapsulation (default)
+val_help: ip; ip encapsulation


### PR DESCRIPTION
Run `sudo modprobe l2tp_ip`, if `set interfaces l2tpv3 l2tpethX encap ip`.
And fix encryption to encapsulation in help messages.
