### PR TITLE
Add system option for ctrl-alt-del-action to configuration

### DIFF
--- a/templates/system/options/ctrl-alt-del-action/node.def
+++ b/templates/system/options/ctrl-alt-del-action/node.def
@@ -12,14 +12,10 @@ end:
   if [ $VAR(@) == "disable" ]; then
     sudo sh -c "sed -i -e 's/^ca.*/ca:12345:ctrlaltdel:/' \
       /etc/inittab"
-  fi
-
-  if [ $VAR(@) == "reboot" ]; then
+  elif [ $VAR(@) == "reboot" ]; then
     sudo sh -c "sed -i -e 's/^ca.*/ca:12345:ctrlaltdel:\/sbin\/reboot/' \
       /etc/inittab"
-  fi
-
-  if [ $VAR(@) == "poweroff" ]; then
+  elif [ $VAR(@) == "poweroff" ]; then
     sudo sh -c "sed -i -e 's/^ca.*/ca:12345:ctrlaltdel:\/sbin\/shutdown -h now/' \
       /etc/inittab"
   fi

--- a/templates/system/options/ctrl-alt-del-action/node.def
+++ b/templates/system/options/ctrl-alt-del-action/node.def
@@ -1,0 +1,28 @@
+type: txt
+
+help: Ctrl-Alt-Delete action
+
+default: "disable"
+
+val_help: disable; Disable Ctrl-Alt-Delete
+val_help: reboot; Reboot VyOS
+val_help: poweroff; Poweroff VyOS
+
+end:
+  if [ $VAR(@) == "disable" ]; then
+    sudo sh -c "sed -i -e 's/^ca.*/ca:12345:ctrlaltdel:/' \
+      /etc/inittab"
+  fi
+
+  if [ $VAR(@) == "reboot" ]; then
+    sudo sh -c "sed -i -e 's/^ca.*/ca:12345:ctrlaltdel:\/sbin\/reboot/' \
+      /etc/inittab"
+  fi
+
+  if [ $VAR(@) == "poweroff" ]; then
+    sudo sh -c "sed -i -e 's/^ca.*/ca:12345:ctrlaltdel:\/sbin\/shutdown -h now/' \
+      /etc/inittab"
+  fi
+
+  # Reload /etc/inittab for change to take effect
+  sudo /sbin/init q

--- a/templates/system/options/ctrl-alt-del-action/node.def
+++ b/templates/system/options/ctrl-alt-del-action/node.def
@@ -8,6 +8,8 @@ val_help: disable; Disable Ctrl-Alt-Delete
 val_help: reboot; Reboot VyOS
 val_help: poweroff; Poweroff VyOS
 
+syntax:expression: $VAR(@) in "disable", "reboot", "poweroff"; "Value must be disable, reboot, or poweroff"
+
 end:
   if [ $VAR(@) == "disable" ]; then
     sudo sh -c "sed -i -e 's/^ca.*/ca:12345:ctrlaltdel:/' \


### PR DESCRIPTION
This new configuration option allows the user to specify
what action to take on ctrl-alt-delete: disable, reboot
or poweroff. By default ctrl-alt-delete-action is set
to disable.

The ctrl-alt-delete action is configured in /etc/inittab.
