### PR TITLE
Add aws ami support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ checkparamsonreboot_SCRIPTS =
 checkparamsonreboot_DATA =
 checkparamsonreboot_DATA += scripts/check-params-on-reboot.d/README
 
+initd_SCRIPTS += etc/init.d/ec2-fetch-ssh-public-key
 initd_SCRIPTS += etc/init.d/vyatta-config-reboot-params
 checkparamsonreboot_SCRIPTS += scripts/check-params-on-reboot.d/ipv6_disable_blacklist
 

--- a/debian/vyatta-cfg-system.postinst.in
+++ b/debian/vyatta-cfg-system.postinst.in
@@ -13,7 +13,7 @@ do
   update-rc.d -f ${init} remove >/dev/null
 done
 
-# remove extra call to clock setup only need one. this speeds up boot 
+# remove extra call to clock setup only need one. this speeds up boot
 # Mystery: why does Debian do it twice?
 if [ -L /etc/rcS.d/S*hwclockfirst.sh -a -L /etc/rcS.d/S*hwclock.sh ]; then
     rm /etc/rcS.d/S*hwclock.sh
@@ -89,7 +89,7 @@ if [ "$sysconfdir" != "/etc" ]; then
 
      # Set file capabilities
     sed -r -e '/^#/d' -e '/^[[:blank:]]*$/d' < $sysconfdir/filecaps | \
-    while read capability path; do 
+    while read capability path; do
        touch -c $path
        setcap $capability $path
     done

--- a/debian/vyatta-cfg-system.postinst.in
+++ b/debian/vyatta-cfg-system.postinst.in
@@ -211,6 +211,14 @@ done
 # add vyatta-config-reboot-params to start at boot up
 update-rc.d vyatta-config-reboot-params start 20 S
 
+# Enable ec2-fetch-ssh-public-key init script
+if [ -f "$sysconfdir"/config/.aws ]; then
+  insserv ec2-fetch-ssh-public-key --default
+
+  # Remove temp. file from install-image-existing L50
+  rm "$sysconfdir"/config/.aws
+fi
+
 # Local Variables:
 # mode: shell-script
 # sh-indentation: 4

--- a/etc/init.d/ec2-fetch-ssh-public-key
+++ b/etc/init.d/ec2-fetch-ssh-public-key
@@ -1,0 +1,114 @@
+#!/bin/bash
+### BEGIN INIT INFO
+# Provides:          ec2-fetch-ssh-public-key
+# Required-Start:    vyatta-router
+# Required-Stop:
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: AWS EC2 instance init script to fetch and load ssh public key
+# Description:       Retrieve user's public ssh key from EC2 instance metadata
+#                    and load/set the key in config.boot
+### END INIT INFO
+
+# Author: hydrajump <wave@hydrajump.com>
+#
+# Based on http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/building-shared-amis.html#public-amis-install-credentials
+#          https://github.com/andsens/bootstrap-vz/blob/master/providers/ec2/assets/init.d/ec2-get-credentials
+
+. /lib/lsb/init-functions
+
+: ${vyatta_env:=/etc/default/vyatta}
+source $vyatta_env
+
+# Configuration commands
+SHELL_API=/bin/cli-shell-api
+COMMIT=/opt/vyatta/sbin/my_commit
+SAVE=/opt/vyatta/sbin/vyatta-save-config.pl
+LOADKEY=/opt/vyatta/sbin/vyatta-load-user-key.pl
+
+public_key_url=http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key
+username='vyos'
+ssh_dir="/home/$username/.ssh"
+authorized_keys="$ssh_dir/authorized_keys"
+group='vyattacfg'
+
+# Obtain config session environment
+session_env=$($SHELL_API getSessionEnv $PPID)
+if [ $? -ne 0 ]; then
+    echo "An error occured while obtaining session environment!"
+    exit 0
+fi
+
+# Evaluate config environment string
+eval $session_env
+
+# Setup the config session
+$SHELL_API setupSession
+if [ $? -ne 0 ]; then
+    echo "An error occured while setting up the configuration session!"
+    exit 0
+fi
+
+load_ssh_public_key ()
+{
+    # Doesn't work.
+    # if [ -x $vyatta_sbindir/vyatta-load-user-key.pl ]; then
+    #     log_action_msg "Loaded ssh public key for user $username"
+    #     sg ${group} -c "$vyatta_sbindir/vyatta-load-user-key.pl $username $public_key"
+    # fi
+
+    # Do this instead
+    # Obtain session environment
+    # Evaluate environment string
+    # Setup the session
+    # Commit and save config change
+    # Tear down the session
+
+    log_action_msg "EC2: Loaded ssh public key for user $username"
+    $LOADKEY $username $public_key_url
+
+    # Commit and save to config.boot
+    $COMMIT
+    $SAVE
+}
+
+# Try to get the ssh public key from instance metadata
+log_action_msg "EC2: -----BEGIN FETCH SSH PUBLIC KEY-----"
+log_action_msg "EC2: Requesting ssh public key from EC2 instance metadata"
+public_key=`/usr/bin/curl --silent -f $public_key_url`
+if [ -n "$public_key" ]; then
+    log_action_msg "EC2: Downloaded ssh public key from EC2 instance metadata"
+    if [ ! -d $ssh_dir ]; then
+        mkdir -m 700 $ssh_dir
+        # chown $username:$username $ssh_dir
+    fi
+
+    # Check if the ssh public key is already loaded
+    if ! grep -s -q "$public_key" $authorized_keys; then
+        load_ssh_public_key
+        # chmod 600 $authorized_keys
+        # chown $username:$username $authorized_keys
+    else
+        log_action_msg "EC2: Already loaded ssh public key for user $username"
+    fi
+else
+    log_action_msg "
+    == WARNING ==
+    No ssh public key found!
+    If you launch an instance without specifying a keypair,
+    you can't connect to the instance.
+    Please terminate this instance and launch a new EC2 instance.
+
+    == IMPORTANT ==
+    Don't forget to create a keypair or select an existing one
+    before you launch the new instance"
+fi
+log_action_msg "EC2: -----END FETCH SSH PUBLIC KEY-----"
+
+# Tear down the config session
+$SHELL_API teardownSession
+if [ $? -ne 0 ]; then
+    echo "An error occured while tearing down the session!"
+    exit 0
+fi
+exit 0

--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -36,6 +36,21 @@ get_grub_index () {
     fi
 }
 
+# Check if installing on AWS EC2 AMI
+is_amazon_ec2_ami () {
+  ami_id_url=http://169.254.169.254/latest/meta-data/ami-id
+
+  ami_id=$(/usr/bin/curl --silent "$ami_id_url")
+  if [ -n "$ami_id" ]; then
+    echo "Installing on VyOS AMI"
+
+    # Create a temporary file to provide conditional
+    # check for init.d config in
+    # /debian/vyatta-cfg-system.postinst.in L215
+    touch ${INST_ROOT}${VYATTA_CFG_DIR}/.aws
+  fi
+}
+
 if [ `whoami` != 'root' ] ; then
   failure_exit 'This script must be run with root privileges.'
 fi
@@ -242,21 +257,33 @@ fi
 DEF_GRUB=${INST_ROOT}${vyatta_sysconfdir}/grub/default-union-grub-entry
 if [ -e "$DEF_GRUB" ]; then
   echo "Setting up grub configuration..."
-  new_index=$(get_grub_index)
 
-  def_grub_vers=/tmp/def_grub.$$
-  cp $DEF_GRUB $def_grub_vers
-  sed -i "s/menuentry \"VyOS.*(/menuentry \"VyOS $NEWNAME (/" $def_grub_vers
-  sed -i "s/menuentry \"Lost password change.*(/menuentry \"Lost password change $NEWNAME (/" $def_grub_vers
-  sed -i "sX/boot/[A-Za-z0-9\.\-]*X/boot/${NEWNAME}Xg" $def_grub_vers
+  if is_amazon_ec2_ami; then
+    sed -i '/menuentry/ i\
+  menuentry '"VyOS AMI (HVM) $NEWNAME"' { \
+    linux /boot/'$NEWNAME'/vmlinuz boot=live quiet vyatta-union=/boot/'$NEWNAME' console=ttyS0 \
+    initrd /boot/'$NEWNAME'/initrd.img \
+  } \
 
-  old_grub_cfg=$BOOT_DIR/grub/grub.cfg
-  new_grub_cfg=/tmp/grub.cfg.$$
-  sed -n '/^menuentry/q;p' $old_grub_cfg >$new_grub_cfg
-  cat $def_grub_vers >> $new_grub_cfg
-  sed -n '/^menuentry/,${p}' $old_grub_cfg >>$new_grub_cfg
-  sed -i "s/^set default=[0-9]\+$/set default=$new_index/" $new_grub_cfg
-  mv $new_grub_cfg $old_grub_cfg
+  ' $BOOT_DIR/grub/grub.cfg
+
+  else
+    new_index=$(get_grub_index)
+
+    def_grub_vers=/tmp/def_grub.$$
+    cp $DEF_GRUB $def_grub_vers
+    sed -i "s/menuentry \"VyOS.*(/menuentry \"VyOS $NEWNAME (/" $def_grub_vers
+    sed -i "s/menuentry \"Lost password change.*(/menuentry \"Lost password change $NEWNAME (/" $def_grub_vers
+    sed -i "sX/boot/[A-Za-z0-9\.\-]*X/boot/${NEWNAME}Xg" $def_grub_vers
+
+    old_grub_cfg=$BOOT_DIR/grub/grub.cfg
+    new_grub_cfg=/tmp/grub.cfg.$$
+    sed -n '/^menuentry/q;p' $old_grub_cfg >$new_grub_cfg
+    cat $def_grub_vers >> $new_grub_cfg
+    sed -n '/^menuentry/,${p}' $old_grub_cfg >>$new_grub_cfg
+    sed -i "s/^set default=[0-9]\+$/set default=$new_index/" $new_grub_cfg
+    mv $new_grub_cfg $old_grub_cfg
+  fi
 
   # Update the default image symlink used by Xen
   if [ -L $BOOT_DIR/%%default_image ]; then

--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -27,7 +27,7 @@ get_grub_index () {
 
     is_kvm=`echo $cur_line | grep KVM`
     is_serial=`echo $cur_line | grep Serial`
-    
+
     # index 0 is KVM, 1 is Serial
     if [ -n "$is_serial" ]; then
 	echo 1
@@ -145,7 +145,7 @@ if [ ! -f "$squash_img" ] || [ -z "$boot_files" ]; then
   becho 'Cannot find the files. Exiting...'
   exit 1
 fi
-target_squash=$REL_ROOT/$NEWVER.squashfs 
+target_squash=$REL_ROOT/$NEWVER.squashfs
 cp -p $squash_img $target_squash >&/dev/null
 cp --no-dereference --preserve=all $boot_files $REL_ROOT/ >&/dev/null
 
@@ -271,4 +271,3 @@ echo 'Done.'
 
 # done
 exit 0
-


### PR DESCRIPTION
- Check if installing on AWS EC2 platform via instance metadata.
- Configure GRUB correctly, so that boot messages are available
  via instance's console.
- Add init.d script to fetch user's EC2 public key during boot.
