### PR TITLE
Added feature to send log message to remote syslog server over UDP or TCP.

### DIFF
--- a/scripts/snmp/vyatta-snmp.pl
+++ b/scripts/snmp/vyatta-snmp.pl
@@ -215,6 +215,12 @@ sub snmp_get_values {
 	print_community($config, $community);
     }
 
+    $config->setLevel("service snmp smuxpeer");
+    my @smuxpeers = $config->returnValues();
+    foreach my $smuxpeer (@smuxpeers) {
+        print "smuxpeer $smuxpeer \n";
+    }
+
     $config->setLevel($snmp_level);
     my $contact = $config->returnValue("contact");
     if (defined $contact) {

--- a/scripts/system/vyatta_update_syslog.pl
+++ b/scripts/system/vyatta_update_syslog.pl
@@ -110,7 +110,16 @@ unless (%entries) {
 read_config( $config, 'console', $CONSOLE );
 
 foreach my $host ( $config->listNodes('host') ) {
-    read_config( $config, "host $host", '@'. $host );
+    my $host_protocol;
+    foreach my $facility ( $config->listNodes("host $host facility") ) {
+        my $protocol = $config->returnValue("host $host facility $facility protocol");
+        if ($protocol eq "tcp") {
+            $host_protocol = "@@";
+        } else {
+            $host_protocol = "@";
+        }
+        read_config( $config, "host $host", $host_protocol. $host );
+    }
 }
 
 foreach my $file ( $config->listNodes('file') ) {

--- a/templates/service/snmp/smuxpeer/node.def
+++ b/templates/service/snmp/smuxpeer/node.def
@@ -1,0 +1,4 @@
+multi:
+type: txt
+help: Register a subtree for SMUX-based processing
+val_help: oid; Object Identifier

--- a/templates/system/syslog/host/node.tag/facility/node.tag/protocol/node.def
+++ b/templates/system/syslog/host/node.tag/facility/node.tag/protocol/node.def
@@ -1,0 +1,6 @@
+type: txt
+help: Syslog communication protocol
+syntax:expression: $VAR(@) in "udp", "tcp";
+                   "Must be \"udp\", or \"tcp\""
+val_help: udp; Send log messages to remote syslog server over UDP
+val_help: tcp; Send log messages to remote syslog server over TCP


### PR DESCRIPTION
See VyOS bug 195 for more information about the feature request. (http://bugzilla.vyos.net/show_bug.cgi?id=195)

The following configuration should be possible to create:

```
        host host1.example.com {
            facility all {
                level debug
            }
        }
        host host2.example.com {
            facility all {
                level info
                protocol tcp
            }
        }
        host host3.example.com {
            facility all {
                protocol udp
            }
        }
```

After commit the following file should be generated:
/etc/rsyslog.d/vyatta-log.conf

```
*.debug @host1.example.com
*.info @@host2.example.com
*.err @host3.example.com
```
