### PR TITLE
Fix AWS EC2 AMI support

### DIFF
--- a/debian/vyatta-cfg-system.postinst.in
+++ b/debian/vyatta-cfg-system.postinst.in
@@ -212,11 +212,11 @@ done
 update-rc.d vyatta-config-reboot-params start 20 S
 
 # Enable ec2-fetch-ssh-public-key init script
-if [ -f "$sysconfdir"/config/.aws ]; then
-  insserv ec2-fetch-ssh-public-key --default
+if [ -f /opt/vyatta/etc/config/.aws ]; then
+  update-rc.d ec2-fetch-ssh-public-key defaults
 
   # Remove temp. file from install-image-existing L50
-  rm "$sysconfdir"/config/.aws
+  rm /opt/vyatta/etc/config/.aws
 fi
 
 # Local Variables:

--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -257,38 +257,34 @@ fi
 DEF_GRUB=${INST_ROOT}${vyatta_sysconfdir}/grub/default-union-grub-entry
 if [ -e "$DEF_GRUB" ]; then
   echo "Setting up grub configuration..."
+  new_index=$(get_grub_index)
 
-  if is_amazon_ec2_ami; then
-    sed -i '/menuentry/ i\
-  menuentry '"VyOS AMI (HVM) $NEWNAME"' { \
-    linux /boot/'$NEWNAME'/vmlinuz boot=live quiet vyatta-union=/boot/'$NEWNAME' console=ttyS0 \
-    initrd /boot/'$NEWNAME'/initrd.img \
-  } \
+  def_grub_vers=/tmp/def_grub.$$
+  cp $DEF_GRUB $def_grub_vers
+  sed -i "s/menuentry \"VyOS.*(/menuentry \"VyOS $NEWNAME (/" $def_grub_vers
+  sed -i "s/menuentry \"Lost password change.*(/menuentry \"Lost password change $NEWNAME (/" $def_grub_vers
+  sed -i "sX/boot/[A-Za-z0-9\.\-]*X/boot/${NEWNAME}Xg" $def_grub_vers
 
-  ' $BOOT_DIR/grub/grub.cfg
-
-  else
-    new_index=$(get_grub_index)
-
-    def_grub_vers=/tmp/def_grub.$$
-    cp $DEF_GRUB $def_grub_vers
-    sed -i "s/menuentry \"VyOS.*(/menuentry \"VyOS $NEWNAME (/" $def_grub_vers
-    sed -i "s/menuentry \"Lost password change.*(/menuentry \"Lost password change $NEWNAME (/" $def_grub_vers
-    sed -i "sX/boot/[A-Za-z0-9\.\-]*X/boot/${NEWNAME}Xg" $def_grub_vers
-
-    old_grub_cfg=$BOOT_DIR/grub/grub.cfg
-    new_grub_cfg=/tmp/grub.cfg.$$
-    sed -n '/^menuentry/q;p' $old_grub_cfg >$new_grub_cfg
-    cat $def_grub_vers >> $new_grub_cfg
-    sed -n '/^menuentry/,${p}' $old_grub_cfg >>$new_grub_cfg
-    sed -i "s/^set default=[0-9]\+$/set default=$new_index/" $new_grub_cfg
-    mv $new_grub_cfg $old_grub_cfg
-  fi
+  old_grub_cfg=$BOOT_DIR/grub/grub.cfg
+  new_grub_cfg=/tmp/grub.cfg.$$
+  sed -n '/^menuentry/q;p' $old_grub_cfg >$new_grub_cfg
+  cat $def_grub_vers >> $new_grub_cfg
+  sed -n '/^menuentry/,${p}' $old_grub_cfg >>$new_grub_cfg
+  sed -i "s/^set default=[0-9]\+$/set default=$new_index/" $new_grub_cfg
+  mv $new_grub_cfg $old_grub_cfg
 
   # Update the default image symlink used by Xen
   if [ -L $BOOT_DIR/%%default_image ]; then
       mv $BOOT_DIR/%%default_image $BOOT_DIR/%%default_image.orig
       ln -s $NEWNAME $BOOT_DIR/%%default_image
+  fi
+
+  # Modify grub.cfg for AWS EC2 AMI
+  if is_amazon_ec2_ami; then
+    sed -i "/menuentry \"VyOS $NEWNAME (Serial/{N;N;N;N;d;}" $BOOT_DIR/grub/grub.cfg
+    sed -i "/menuentry \"Lost password change $NEWNAME/{N;N;N;N;d;}" $BOOT_DIR/grub/grub.cfg
+    sed -i "s/VyOS $NEWNAME (KVM console)/VyOS AMI (HVM) $NEWNAME/" $BOOT_DIR/grub/grub.cfg
+    sed -i "s/$NEWNAME console=ttyS0.*/$NEWNAME console=ttyS0/" $BOOT_DIR/grub/grub.cfg
   fi
 fi
 


### PR DESCRIPTION
- grub.cfg is now correctly modified when installing on a VyOS AMI
- ec2-fetch-ssh-public-key init script still needs to be activated
  if installing on a VyOS AMI. This is an outstanding issue which
  needs to be addressed. See debian/vyatta-cfg-system.postinst.in.
