### PR TITLE
Fix to enable ec2-fetch-ssh-public-key init script

### DIFF
--- a/debian/vyatta-cfg-system.postinst.in
+++ b/debian/vyatta-cfg-system.postinst.in
@@ -211,14 +211,6 @@ done
 # add vyatta-config-reboot-params to start at boot up
 update-rc.d vyatta-config-reboot-params start 20 S
 
-# Enable ec2-fetch-ssh-public-key init script
-if [ -f /opt/vyatta/etc/config/.aws ]; then
-  update-rc.d ec2-fetch-ssh-public-key defaults
-
-  # Remove temp. file from install-image-existing L50
-  rm /opt/vyatta/etc/config/.aws
-fi
-
 # Local Variables:
 # mode: shell-script
 # sh-indentation: 4

--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -44,10 +44,8 @@ is_amazon_ec2_ami () {
   if [ -n "$ami_id" ]; then
     echo "Installing on VyOS AMI"
 
-    # Create a temporary file to provide conditional
-    # check for init.d config in
-    # /debian/vyatta-cfg-system.postinst.in L215
-    touch ${INST_ROOT}${VYATTA_CFG_DIR}/.aws
+    # Create init script links for /etc/init.d/ec2-fetch-ssh-public-key
+    chroot $INST_ROOT update-rc.d ec2-fetch-ssh-public-key defaults &>/dev/null
   fi
 }
 


### PR DESCRIPTION
The init script was not running on boot because the init script
symlinks were not created in /etc/rcX.d for the runlevels: 2,3,4,5.

This fix runs the update-rc.d command in the is_amazon_ec2_ami
function, thus creating the required symlinks and also updating
/etc/init.d/.depends.on.start.
