### PR TITLE
Add support for ciphers and macs override in ssh

### DIFF
--- a/templates/service/ssh/ciphers/node.def
+++ b/templates/service/ssh/ciphers/node.def
@@ -1,0 +1,10 @@
+type: txt
+help: Specifies the ciphers allowed for protocol version 2.  Multiple ciphers must be comma-separated. See 'man sshd_config' for supported ciphers.
+
+create: sudo sed -i -e '$ a \
+Ciphers $VAR(@)' /etc/ssh/sshd_config
+
+delete: sudo sed -i -e '/^Ciphers $VAR(@)$/d' /etc/ssh/sshd_config
+
+update: sudo sed -i -e '/^Ciphers/c \
+Ciphers $VAR(@)' /etc/ssh/sshd_config

--- a/templates/service/ssh/macs/node.def
+++ b/templates/service/ssh/macs/node.def
@@ -1,0 +1,10 @@
+type: txt
+help: Specifies the available MAC (message authentication code) algorithms. The MAC algorithm is used in protocol version 2 for data integrity protection. Multiple algorithms must be comma-separated. See 'man sshd_config' for supported MACs.
+
+create: sudo sed -i -e '$ a \
+MACs $VAR(@)' /etc/ssh/sshd_config
+
+delete: sudo sed -i -e '/^MACs $VAR(@)$/d' /etc/ssh/sshd_config
+
+update: sudo sed -i -e '/^MACs/c \
+MACs $VAR(@)' /etc/ssh/sshd_config


### PR DESCRIPTION
By default, the SSH server allows connections using weak cipher and MAC algorithms. This commit adds support to override the default Ciphers and MACs options in SSH server.

For example:
set service ssh ciphers aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128,arcfour
set service ssh macs hmac-sha1,hmac-ripemd160
