### PR TITLE
vyatta-cfg-system: remove quotes from SysContact and SysLocation

### DIFF
--- a/scripts/snmp/vyatta-snmp.pl
+++ b/scripts/snmp/vyatta-snmp.pl
@@ -224,17 +224,17 @@ sub snmp_get_values {
     $config->setLevel($snmp_level);
     my $contact = $config->returnValue("contact");
     if (defined $contact) {
-	print "syscontact \"$contact\" \n";
+        print "SysContact $contact \n";
     }
 
     my $description = $config->returnValue("description");
     if (defined $description) {
-	print "sysdescr \"$description\" \n";
+        print "SysDescr $description \n";
     }
 
     my $location = $config->returnValue("location");
     if (defined $location) {
-	print "syslocation \"$location\" \n";
+        print "SysLocation $location \n";
     }
 }
 

--- a/templates/service/snmp/contact/node.def
+++ b/templates/service/snmp/contact/node.def
@@ -1,2 +1,6 @@
 type: txt
 help: Contact information
+
+syntax:expression: pattern $VAR(@) "^[[:print:]]{1,255}$" ; \
+                   "Contact information is limited to 255 characters or less"
+

--- a/templates/service/snmp/description/node.def
+++ b/templates/service/snmp/description/node.def
@@ -1,2 +1,6 @@
 type: txt
 help: Description information
+
+syntax:expression: pattern $VAR(@) "^[[:print:]]{1,255}$" ; \
+                   "Description is limited to 255 characters or less"
+

--- a/templates/service/snmp/location/node.def
+++ b/templates/service/snmp/location/node.def
@@ -1,3 +1,6 @@
 type: txt
 help: Location information
 
+syntax:expression: pattern $VAR(@) "^[[:print:]]{1,255}$" ; \
+                   "Location is limited to 255 characters or less"
+


### PR DESCRIPTION
When the values for SysContact, SysLocation and SysDecr are written to
the snmpd.conf file, they are enclosed in backslash escaped quotes.
This isn't part of the syntax for snmpd.conf and looks wrong / could
break snmp related things, the example snmpd.conf files show these
values as unquoted.

This patch corrects the output and adds validation for the supplied
values, limiting them to a maximum of 255 printable characters
(RFC 3418).

The documentation also needs amending to take this into account.

Bug #261 http://bugzilla.vyos.net/show_bug.cgi?id=261
