### PR TITLE
vyatta-cfg-system: revert bb71cf5b7b3a48812e28dbefba8c535f9bbf9973

### DIFF
--- a/scripts/system/vyatta_update_resolv.pl
+++ b/scripts/system/vyatta_update_resolv.pl
@@ -128,12 +128,12 @@ if (($dhclient_script == 1) && !($vc->existsOrig('name-server'))) {
                         }
                     }
                     if ($ns_in_resolvconf == 0) {
-		        open (my $rf, '>>', '/etc/resolv.conf')
-		            or die "$! error trying to overwrite";
-		        print $rf "#nameserver\t$ns\t\t#nameserver written by $0\n";
-		        print $rf "nameserver\t$ns\n";
-		        close $rf;
-		        $restart_ntp = 1;
+                        open (my $rf, '>>', '/etc/resolv.conf')
+                            or die "$! error trying to overwrite";
+                        print $rf "#nameserver\t$ns\t\t#nameserver written by $0\n";
+                        print $rf "nameserver\t$ns\n";
+                        close $rf;
+                        $restart_ntp = 1;
                     }
                 }
             }

--- a/scripts/system/vyatta_update_resolv.pl
+++ b/scripts/system/vyatta_update_resolv.pl
@@ -130,8 +130,7 @@ if (($dhclient_script == 1) && !($vc->existsOrig('name-server'))) {
                     if ($ns_in_resolvconf == 0) {
                         open (my $rf, '>>', '/etc/resolv.conf')
                             or die "$! error trying to overwrite";
-                        print $rf "#nameserver\t$ns\t\t#nameserver written by $0\n";
-                        print $rf "nameserver\t$ns\n";
+                        print $rf "nameserver\t$ns\t\t#nameserver written by $0\n";
                         close $rf;
                         $restart_ntp = 1;
                     }


### PR DESCRIPTION
Reverting commit bb71cf5b7b3a48812e28dbefba8c535f9bbf9973 as it breaks
the logic in vyatta_update_resolv.pl for removing name servers when
called by dhclient-script.  As it stands, the commit causes name server
entries to be left behind in resolv.conf when a DHCP interface is 
deleted, resulting in possibly old or invalid entries remaining 
indefinitely.

Bug #307 http://bugzilla.vyos.net/show_bug.cgi?id=307
