### PR TITLE
 vyatta-cfg-system: add 'set system allow-dhcp-nameservers' option

### DIFF
--- a/scripts/system/vyatta_update_resolv.pl
+++ b/scripts/system/vyatta_update_resolv.pl
@@ -94,8 +94,8 @@ if ($domain_name && length($domain_name) > 0) {
 }
 
 # update /etc/resolv.conf for name-servers received from dhcp client, only done when dhclient-script calls this script
-# and there aren't statically configured DNS settings, via 'set system name-server', in place.
-if (($dhclient_script == 1) && !($vc->existsOrig('name-server'))) {
+# and allow-dhcp-nameservers is set to true (default)
+if (($dhclient_script == 1) && ($vc->returnOrigValue('allow-dhcp-nameservers') eq "true")) {
     my @current_dhcp_nameservers;
     my $restart_ntp = 0;
 

--- a/templates/system/allow-dhcp-nameservers/node.def
+++ b/templates/system/allow-dhcp-nameservers/node.def
@@ -1,0 +1,4 @@
+priority: 300
+type: bool
+help: Allow DHCP to update DNS settings
+default: true 


### PR DESCRIPTION
Instead of simply allowing / denying DHCP related updates to resolv.conf
based on the current values of 'set system name-server', as initially
proposed for Bug #182 (http://bugzilla.vyos.net/show_bug.cgi?id=182),
this patch replaces that behaviour with a global option to allow /
deny these updates.

Add 'set system allow-dhcp-nameservers' as a boolean value that has the
default value of true, so allowing DHCP nameserver updates by default.

Bug #308 http://bugzilla.vyos.net/show_bug.cgi?id=308
