### PR TITLE
vyatta-cfg-system: rename allow-dhcp-nameservers and change to typeless

### DIFF
--- a/templates/system/allow-dhcp-nameservers/node.def
+++ b/templates/system/allow-dhcp-nameservers/node.def
@@ -1,7 +1,0 @@
-priority: 300
-type: bool
-help: Allow DHCP to update DNS settings
-default: true 
-
-update: sudo /opt/vyatta/sbin/vyatta_update_resolv.pl --config-mode 1
-delete: sudo /opt/vyatta/sbin/vyatta_update_resolv.pl --config-mode 1

--- a/templates/system/disable-dhcp-nameservers/node.def
+++ b/templates/system/disable-dhcp-nameservers/node.def
@@ -1,0 +1,5 @@
+priority: 300
+help: Disable DHCP updates of DNS settings 
+
+create: sudo /opt/vyatta/sbin/vyatta_update_resolv.pl --config-mode 1
+delete: sudo /opt/vyatta/sbin/vyatta_update_resolv.pl --config-mode 1


### PR DESCRIPTION
Rename allow-dhcp-nameservers to disable-dhcp-nameservers and update
the logic to take the new meaning into account.  The option is now also
typeless, so the node is either absent (default) or present (enabled).

Format 'set / delete system disable-dhcp-nameservers'

Linked to Bug #182 and Bug #308

Bug #314 http://bugzilla.vyos.net/show_bug.cgi?id=314
