### PR TITLE
vyatta-cfg-system: allow dhcp and dhcpv6 addresses to be deleted

### DIFF
--- a/scripts/vyatta-address
+++ b/scripts/vyatta-address
@@ -28,8 +28,11 @@ case $1 in
     delete)
         # Get current address from interface when using DHCP
         if [[ "$3" = "dhcp" ]]; then
-            file=/var/lib/dhcp3/dhclient_"$2"_lease;
-            ip_address=$(sed -n "/new_ip_address='/ s/.*\='*//p" $file | sed -n "s/'//p");
+            lease_file=/var/lib/dhcp3/dhclient_"$2".leases;
+            ip_address=$(sed -n 's/^\s\sfixed-address\s\(.*\);/\1/p' $lease_file | sed -n '$p');
+        elif [[ "$3" = "dhcpv6" ]]; then
+            lease_file=/var/lib/dhcp3/dhclient_v6_"$2".leases;
+            ip_address=$(sed -n 's/^\s\s\s\siaaddr\s\(.*\)\s{/\1/p' $lease_file | sed -n '$p');        
         else
             ip_address=$3;
         fi


### PR DESCRIPTION
Allow interfaces with either dhcp or dhcpv6 addresses to be deleted.
Expand on the previous patch for Bug #305 to now take dhcpv6 addresses
into account, as well as an update to the original dhcp logic.

Bug #341 http://bugzilla.vyos.net/show_bug.cgi?id=341
