### PR TITLE
Add initial support for configuring Vyos via EC2 instance user-data.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,7 @@ checkparamsonreboot_SCRIPTS =
 checkparamsonreboot_DATA =
 checkparamsonreboot_DATA += scripts/check-params-on-reboot.d/README
 
-initd_SCRIPTS += etc/init.d/ec2-fetch-ssh-public-key
+initd_SCRIPTS += etc/init.d/ec2-vyos-init
 initd_SCRIPTS += etc/init.d/vyatta-config-reboot-params
 initd_SCRIPTS += etc/init.d/vyos-intfwatchd
 checkparamsonreboot_SCRIPTS += scripts/check-params-on-reboot.d/ipv6_disable_blacklist

--- a/debian/vyatta-cfg-system.postinst.in
+++ b/debian/vyatta-cfg-system.postinst.in
@@ -214,8 +214,8 @@ update-rc.d vyatta-config-reboot-params start 20 S
 # set vyos-intfwatchd to start at boot
 update-rc.d vyos-intfwatchd start 2345
 
-# set ec2-fetch-ssh-public-key to start on boot
-update-rc.d ec2-fetch-ssh-public-key start 2345
+# set ec2-vyos-init to start on boot
+update-rc.d ec2-vyos-init start 2345
 
 # Local Variables:
 # mode: shell-script

--- a/etc/init.d/ec2-vyos-init
+++ b/etc/init.d/ec2-vyos-init
@@ -1,6 +1,6 @@
 #!/bin/bash
 ### BEGIN INIT INFO
-# Provides:          ec2-fetch-ssh-public-key
+# Provides:          ec2-vyos-init
 # Required-Start:    vyatta-router
 # Required-Stop:
 # Default-Start:     2 3 4 5
@@ -37,7 +37,9 @@ SHELL_API=/bin/cli-shell-api
 COMMIT=/opt/vyatta/sbin/my_commit
 SAVE=/opt/vyatta/sbin/vyatta-save-config.pl
 LOADKEY=/opt/vyatta/sbin/vyatta-load-user-key.pl
+LOADCONFIG=/opt/vyatta/sbin/vyatta-load-config.pl
 
+userdata_url=http://169.254.169.254/latest/user-data
 public_key_url=http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key
 username='vyos'
 ssh_dir="/home/$username/.ssh"
@@ -60,6 +62,13 @@ if [ $? -ne 0 ]; then
     echo "An error occured while setting up the configuration session!"
     exit 0
 fi
+
+load_user_data ()
+{
+    $LOADCONFIG $userdata_url
+    $COMMIT
+    $SAVE
+}
 
 load_ssh_public_key ()
 {
@@ -84,6 +93,17 @@ load_ssh_public_key ()
     $SAVE
 }
 
+# Try to load config from instance user-data
+log_action_msg "EC2: -----BEGIN FETCH CONFIG-----"
+log_action_msg "EC2: Requesting config from EC2 instance user-data"
+if (curl --silent -f $userdata_url | grep 'vyatta-config-version' >/dev/null); then
+    log_action_msg "EC2: Found Vyos config in EC2 instance user-data"
+    load_user_data
+else
+    log_action_msg "EC2: No Vyos config found in EC2 instance user-data"
+fi
+
+log_action_msg "EC2: -----END FETCH CONFIG-----"
 # Try to get the ssh public key from instance metadata
 log_action_msg "EC2: -----BEGIN FETCH SSH PUBLIC KEY-----"
 log_action_msg "EC2: Requesting ssh public key from EC2 instance metadata"

--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -49,8 +49,8 @@ is_amazon_ec2_ami () {
   if [ -n "$ami_id" ]; then
     echo "Installing on VyOS AMI"
 
-    # Create init script links for /etc/init.d/ec2-fetch-ssh-public-key
-    chroot $INST_ROOT update-rc.d ec2-fetch-ssh-public-key defaults &>/dev/null
+    # Create init script links for /etc/init.d/ec2-vyos-init
+    chroot $INST_ROOT update-rc.d ec2-vyos-init defaults &>/dev/null
 
     # Dijkstra, forgive us!
     return 0


### PR DESCRIPTION
ec2-fetch-ssh-public-key has been renamed to ec2-vyos-init, and now checks for and loads any configuration file in the EC2 instance's user-data.
