### PR TITLE
adding support for "remote" attribute of VXLAN tunnel

### DIFF
--- a/templates/interfaces/vxlan/node.def
+++ b/templates/interfaces/vxlan/node.def
@@ -5,8 +5,6 @@ help: Virtual eXtensible LAN interface
 val_help: <vxlanN>; VXLAN interface name
 syntax:expression: pattern $VAR(@) "vxlan[0-9]+$"
 
-commit:expression: $VAR(./group/) != "";	\
-		   "Must configure vxlan group for $VAR(@)"
 commit:expression: $VAR(./vni/) != "";			\
 		   "Must configure vxlan vni for $VAR(@)"
 
@@ -20,12 +18,25 @@ create:
     exit 1
   fi
 
+  VXLAN_GROUP=""
   VXLAN_VNI="id $VAR(./vni/@)"
-  VXLAN_GROUP="group $VAR(./group/@)"
   VXLAN_TTL="ttl 16"
 
   if [ ! $VAR(./link/) == "" ]; then
     VXLAN_DEV="dev $VAR(./link/@)"
+  fi
+
+  if [ ! $VAR(./group/) == "" ]; then
+    VXLAN_GROUP="group $VAR(./group/@)"
+  fi
+
+  if [ ! $VAR(./remote/) == "" ]; then
+    VXLAN_GROUP="remote $VAR(./remote/@)"
+  fi
+
+  if [ -z "$VXLAN_GROUP" ]; then
+    echo "group or remote must be configured."
+    exit 1
   fi
 
   ip link add name $VAR(@) type vxlan 	\

--- a/templates/interfaces/vxlan/node.tag/group/node.def
+++ b/templates/interfaces/vxlan/node.tag/group/node.def
@@ -1,6 +1,6 @@
 type: ipv4
-help: Multicast group address for this VXLAN interface [REQUIRED]
-val_help: ipv4; Multicast group address for this VXLAN [REQUIRED]
+help: Multicast group address for this VXLAN interface
+val_help: ipv4; Multicast group address for this VXLAN
 
 update:
   if [ ! -e /tmp/vxlan-$VAR(../@)-create ]; then

--- a/templates/interfaces/vxlan/node.tag/remote/node.def
+++ b/templates/interfaces/vxlan/node.tag/remote/node.def
@@ -1,0 +1,9 @@
+type: ipv4
+help: Remote address of VXLAN tunnel
+val_help: ipv4; Remote address of this VXLAN tunnel
+
+update:
+  if [ ! -e /tmp/vxlan-$VAR(../@)-create ]; then
+    echo "Chainging remote requires delete/create this vxlan interface"
+    exit 1
+  fi


### PR DESCRIPTION
I added "remote" under _interfaces vxlan vxlanX_.
It supports vxlan point-to-point tunneling without IP mutlicast (it is known as unicast mode).
