### PR TITLE
Fix Bug#382. (Another fix).

### DIFF
--- a/templates/system/ipv6/disable-forwarding/node.def
+++ b/templates/system/ipv6/disable-forwarding/node.def
@@ -38,7 +38,7 @@ delete:
 	# forwarding was disabled, we will need to start the radvd daemon
 	# now.
 	running=$(pgrep -n radvd)
- 	if [[ $running -eq 0 ]] &&
+ 	if [[ -z "$running" ]] &&
            [[ -e /etc/radvd.conf ]] &&
            [[ -x /etc/init.d/radvd ]]; then
 		/etc/init.d/radvd start


### PR DESCRIPTION
If radvd is not running, the pgrep command returns an empty string, not zero.

Reported-by Carl Byington vyos-bug@five-ten-sg.com
