### PR TITLE
Add flexibility to dynamic dns configuration (#507)

### DIFF
--- a/templates/service/dns/dynamic/interface/node.tag/service/node.def
+++ b/templates/service/dns/dynamic/interface/node.tag/service/node.def
@@ -1,23 +1,9 @@
 tag:
 help: Service being used for Dynamic DNS [REQUIRED]
 type: txt
-syntax:expression: exec "
-        service_array=(afraid dnspark dslreports dyndns easydns namecheap noip sitelutions zoneedit)
-        service_array_len=${#service_array[*]}
-        i=0
-        while [ $i -lt $service_array_len ]; do
-             if [ \"${service_array[$i]}\" == \"$VAR(@)\" ] ; then
-                   exit 0
-             fi
-             let i++
-        done
-        echo Invalid service [$VAR(@)]
-        exit 1 "
 
-allowed: local -a array ;
-         array=(afraid dnspark dslreports dyndns easydns namecheap noip sitelutions zoneedit);
-         echo -n ${array[@]}
+val_help: txt; Custom or predefined service
 
-commit:expression: $VAR(./@/login) != ""; "Set login for service $VAR(./@) to send DDNS updates for interface $VAR(../@)"
-commit:expression: $VAR(./@/password) != ""; "Set password for service $VAR(./@) to send DDNS updates for interface $VAR(../@)"
-commit:expression: $VAR(./@/host-name) != ""; "Set atleast one host-name registered with service $VAR(./@) to send DDNS updates for interface $VAR(../@)"
+allowed:/opt/vyatta/sbin/vyatta-dynamic-dns.pl --interface $VAR(../@) --get-services
+ 
+commit:expression: exec "/opt/vyatta/sbin/vyatta-dynamic-dns.pl --interface $VAR(../@) --check-nodes"

--- a/templates/service/dns/dynamic/interface/node.tag/service/node.tag/protocol/node.def
+++ b/templates/service/dns/dynamic/interface/node.tag/service/node.tag/protocol/node.def
@@ -1,0 +1,3 @@
+help: ddclient protocol to be used for dynamic dns service [REQUIRED FOR CUSTOM SERVICES]
+type: txt
+val_help: <protocol>; ddclient protocol (see ddclient manual) 

--- a/templates/service/dns/dynamic/interface/node.tag/service/node.tag/server/node.def
+++ b/templates/service/dns/dynamic/interface/node.tag/service/node.tag/server/node.def
@@ -1,4 +1,4 @@
-help: Server to send DDNS update to (IP address|hostname)
+help: Server to send DDNS update to (IP address|hostname) [REQUIRED FOR SERVICES]
 type: txt
 val_help: ipv4; IP address of DDNS server
 val_help: <hostname>; Hostname of DDNS server


### PR DESCRIPTION
This will preserve backwards compatibility while allowing such configuration :

```
# edit service dns dynamic interface eth0 service HeNet
# set login my-login
# set password my-password
# set host-name my-tunnel-id
# set protocol dyndns2
# set server ipv4.tunnelbroker.net
```

A bunch of "default services" are supported out of the box, full list is here : https://github.com/vyos/vyatta-cfg-system/blob/af6f00be213aaa0a74977e58130c8aede7ad2f22/scripts/dynamic-dns/vyatta-dynamic-dns.pl#L42

This will make it trivial to add/update/remove supported services.
