### PR TITLE
Fix resolv-file configuration problem

### DIFF
--- a/scripts/dns-forwarding/vyatta-dns-forwarding.pl
+++ b/scripts/dns-forwarding/vyatta-dns-forwarding.pl
@@ -155,7 +155,7 @@ sub dnsforwarding_get_values {
     }
 
     if ($use_dnsmasq_conf == 1) {
-        $output .= "resolv-file=/etc/dnsmasq.conf\n";
+        $output .= "resolv-file=/etc/resolv.conf\n";
     }
 
     return $output;


### PR DESCRIPTION
When using `service dns forwarding system`, dnsmasq will use system nameservers to resolve DNS instead of nameservers that statically configured with `server=` directive in /etc/dnsmasq.conf.

In this case `resolv-file=` directive in /etc/dnsmasq.conf must point to `/etc/resolv.conf` (or any separated resolveconf file like `/etc/resolv.dnsmasq.conf`), but not `/etc/dnsmasq.conf` itself.
