### PR TITLE
Allow full integer range for GRE tunnel key

### DIFF
--- a/templates/interfaces/tunnel/node.tag/parameters/ip/key/node.def
+++ b/templates/interfaces/tunnel/node.tag/parameters/ip/key/node.def
@@ -1,8 +1,8 @@
 type: u32
 help: Tunnel key
-syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 999999; \
-                   "Must be between 0-999999 for $VAR(../../../@)"
-val_help: u32:0-999999; Tunnel key
+syntax:expression: $VAR(@) >= 0 && $VAR(@) <= 4294967295; \
+                   "Must be between 0-4294967295 for $VAR(../../../@)"
+val_help: u32:0-4294967295; Tunnel key
 
 syntax:expression: exec " \
    if [ -n \"`ip tunnel show $VAR(../../../@) | grep $VAR(../../../@) `\" ]; then \


### PR DESCRIPTION
The key for GRE tunnels (interfaces tunnel tunX parameters ip key) is arbitrarily limited to the range 0-999999.

Cisco devices for example accept an ID in the full integer range (0-4294967295).

Fixes T262

	modified: templates/interfaces/tunnel/node.tag/parameters/ip/key/node.def