### PR TITLE
Fix to generate correct NTP config when specifying ipv6 servers.

### DIFF
--- a/scripts/system/vyatta_update_ntp.pl
+++ b/scripts/system/vyatta_update_ntp.pl
@@ -35,19 +35,14 @@ sub ntp_format {
     if (defined($ip)) {
         my $address = $ip->addr();
         my $mask = $ip->mask();
-    
-        if ($ip->masklen() == 32) {
-            if ($ip->version() == 6) {
-                return "-6 $address";
-            } else {
-                return "$address";
-            }
+
+        if (
+          ($ip->version() == 6 && $ip->masklen() == 128)
+          || ($ip->version() == 4 && $ip->masklen() == 32)
+        ) {
+          return "$address";
         } else {
-            if ($ip->version() == 6) {
-                return "-6 $address mask $mask";
-            } else {
-                return "$address mask $mask";
-            }
+          return "$address mask $mask";
         }
     } else {
         return undef;


### PR DESCRIPTION
The generated configuration for NTP is wrong when IPv6 NTP server is specified.
It shows error message like this.

/var/log/messages
```
...(snip)...
Jun 11 23:49:19 XXXXX ntpd[14013]: proto: precision = 1.100 usec
Jun 11 23:49:19 XXXXX ntpd[14013]: line 30 column 38 syntax error, unexpected T_Mask, expecting T_EOC
Jun 11 23:49:19 XXXXX ntpd[14013]: syntax error in /etc/ntp.conf line 30, column 38
Jun 11 23:49:19 XXXXX ntpd[14013]: line 31 column 40 syntax error, unexpected T_Mask, expecting T_EOC
Jun 11 23:49:19 XXXXX ntpd[14013]: syntax error in /etc/ntp.conf line 31, column 40
...(snip)...
```

The original script generates the config file like this.
/etc/ntp.conf
```
...(snip)...
30 server -6 2001:3A0:0:2006:0:0:87:123 mask FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF iburst
31 restrict -6 2001:3A0:0:2006:0:0:87:123 mask FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF nomodify notrap nopeer noquery
...(snip)...
```
These lines should not include `mask` clause.
