### PR TITLE
T331: root should be set to md/X instead of md/mdX

### DIFF
--- a/scripts/vyatta-grub-setup
+++ b/scripts/vyatta-grub-setup
@@ -178,7 +178,7 @@ fi
 	echo ""
 	echo -e "insmod mdraid09"
 	echo -e "insmod mdraid1x"
-	echo -e "set root=(md/$ROOT_PARTITION)"
+	echo -e "set root=(md/${ROOT_PARTITION#md})"
     fi
 
     echo ""


### PR DESCRIPTION
The script set the root to md/md0, while it should have set to md/0.
Tested on kvm and bare metal.