### PR TITLE
Add fail2ban system service

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,7 @@ Depends:  adduser,
  parted,
  libsnmp-perl,
  libpam-cap,
+ fail2ban,
  ${arch:Depends}
 Pre-Depends: bash-completion
 Suggests: util-linux (>= 2.13-5),

--- a/templates/system/fail2ban/enable/node.def
+++ b/templates/system/fail2ban/enable/node.def
@@ -1,0 +1,8 @@
+priority: 900
+help: Enable Fail2ban service
+end:
+    if [ "$COMMIT_ACTION" == DELETE ]; then
+        sudo /etc/init.d/fail2ban stop
+    else
+        sudo /etc/init.d/fail2ban start
+    fi

--- a/templates/system/fail2ban/node.def
+++ b/templates/system/fail2ban/node.def
@@ -1,0 +1,1 @@
+help: Fail2ban system service


### PR DESCRIPTION
Fail2Ban is an intrusion prevention software framework that protects computer
servers from brute-force attacks.

service {
    fail2ban {
        enable
    }
}