### PR TITLE
Add ecc support to openssh

### DIFF
--- a/scripts/vyatta-load-user-key.pl
+++ b/scripts/vyatta-load-user-key.pl
@@ -103,7 +103,7 @@ sub geturl {
 
 sub validate_keytype {
     my ($keytype) = @_;
-    if ($keytype eq 'ssh-rsa' || $keytype eq 'ssh-dss') {
+    if ($keytype eq 'ssh-rsa' || $keytype eq 'ssh-dss' || $keytype eq 'ecdsa-sha2-nistp256' || $keytype eq 'ecdsa-sha2-nistp384' || $keytype eq 'ecdsa-sha2-nistp521' || $keytype eq 'ssh-ed25519') {
         return 1;
     }
     return 0;
@@ -135,7 +135,7 @@ sub getkeys {
 	my $comment;
 	$comment = join(' ', @fields);
 
-	die "Unknown key type $keytype : must be ssh-rsa or ssh-dss\n"
+	die "Unknown key type $keytype : must be one of ssh-rsa, ssh-dss, ecdsa-sha2-nistp* or ssh-ed25519\n"
 	    unless validate_keytype $keytype;
 
 	my $cmd

--- a/templates/system/login/user/node.tag/authentication/public-keys/node.tag/type/node.def
+++ b/templates/system/login/user/node.tag/authentication/public-keys/node.tag/type/node.def
@@ -1,4 +1,4 @@
 type: txt
 help: Public key type
-allowed: echo "ssh-dss ssh-rsa"
-syntax:expression: $VAR(@) in "ssh-rsa", "ssh-dss" ; "Unknown key type"
+allowed: echo "ssh-dss ssh-rsa ecdsa-sha2-nistp256 ecdsa-sha2-nistp384 ecdsa-sha2-nistp521 ssh-ed25519"
+syntax:expression: $VAR(@) in "ssh-rsa", "ssh-dss", "ecdsa-sha2-nistp256", "ecdsa-sha2-nistp384", "ecdsa-sha2-nistp521", "ssh-ed25519"; "Unknown key type"


### PR DESCRIPTION
Added option to import ecdsa & ed25519 keys for remote access.
What is the recommended way to make this submodule in 1.2.x?
Unfortunately the documentation is not very clear on that. I found this wiki for the stable branch:
[https://wiki.vyos.net/wiki/Source_code#Building_a_submodule](url)
This doesnt work on current. Is it okay to make the package with `dpkg-buildpackage`?