### PR TITLE
Update vyatta_update_ntp.pl

### DIFF
--- a/scripts/system/vyatta_update_ntp.pl
+++ b/scripts/system/vyatta_update_ntp.pl
@@ -87,18 +87,15 @@ if ($dhclient_script == 1) {
 if (scalar(@servers) > 0) {
     print $output "# Servers\n\n";
     foreach my $server (@servers) {
-        my $server_addr = ntp_format($server);
-        if (defined($server_addr)) {
-            print $output "server $server_addr iburst";
-            for my $property (qw(dynamic noselect preempt prefer)) {
-                if ($dhclient_script == 1) {
-                    print $output " $property" if ($cfg->existsOrig("server $server $property"));
-                } else {
-                    print $output " $property" if ($cfg->exists("server $server $property"));
-                }
+        print $output "server $server iburst";
+        for my $property (qw(dynamic noselect preempt prefer)) {
+            if ($dhclient_script == 1) {
+                print $output " $property" if ($cfg->existsOrig("server $server $property"));
+            } else {
+                print $output " $property" if ($cfg->exists("server $server $property"));
             }
-            print $output "\nrestrict $server_addr nomodify notrap nopeer noquery\n";
         }
+        print $output "\nrestrict $server nomodify notrap nopeer noquery\n";
     }
     print $output "\n";
 }


### PR DESCRIPTION
Remove unavoidable ip address resolve in config time. If one uses, say, pool.ntp.org, IP address can disappear after some time. And if DNS is unavailable in configuration-commit time, one ends with empty and non-working ntp.conf with no notices in CLI on this issue.
Now, one has to decide, what will be passed into ntp.conf exactly - IP or domain name.