### PR TITLE
Cleans up an old reference to dnsmasq in static-host-mapping

### DIFF
--- a/templates/system/static-host-mapping/host-name/node.def
+++ b/templates/system/static-host-mapping/host-name/node.def
@@ -12,10 +12,10 @@ end: sudo sh -c "
   touch /etc/hosts
   sed -i '/ $VAR(@) .*#vyatta entry/d' /etc/hosts
   if [ -z \"$VAR(./inet/@)\" ]; then
-     if cli-shell-api existsActive service dns forwarding; then /etc/init.d/dnsmasq restart >&/dev/null; fi
+     if cli-shell-api existsActive service dns forwarding; then /etc/init.d/pdns-recursor restart >&/dev/null; fi
      exit 0
   fi
   declare -a aliases=( $VAR(alias/@@) )
   echo -e \"$VAR(inet/@)\\t $VAR(@) \${aliases[*]} \\t #vyatta entry\" >> /etc/hosts
-  if cli-shell-api existsActive service dns forwarding; then /etc/init.d/dnsmasq restart >&/dev/null; fi"
+  if cli-shell-api existsActive service dns forwarding; then /etc/init.d/pdns-recursor restart >&/dev/null; fi"
 


### PR DESCRIPTION
I found this when I tried to commit a change after enabling DNS forwarding.

I tested this by editing the file on my installed version. Commit worked for my change and the name I added was resolvable via pdns_recursor.

Version:          VyOS 1.2.0-rolling+201805310337