### PR TITLE
T967: Support NVMe drives in installer

### DIFF
--- a/scripts/install/install-functions
+++ b/scripts/install/install-functions
@@ -151,7 +151,7 @@ get_drive_size () {
 # Probe hardrives not shown in /proc/partitions by default
 probe_drives () {
   # Find drives that may not be in /proc/partitions since not mounted
-  drive=$(ls /sys/block  | grep '[hsv]d.')
+  drive=$(ls /sys/block  | grep '[hsv]d.|nvme.')
 
   # now exclude all drives that are read-only
   for drive in $drive; do

--- a/scripts/install/install-functions
+++ b/scripts/install/install-functions
@@ -176,7 +176,7 @@ select_drive () {
   # the first grep pattern looks for devices named c0d0, hda, and sda.
   drives=$(cat /proc/partitions | \
            awk '{ if ($4!="name") { print $4 } }' | \
-           egrep "c[0-9]d[0-9]$|[hsv]d[a-z]$" | \
+           egrep "c[0-9]d[0-9]$|[hsv]d[a-z]$|nvme[0-9]n[0-9]" | \
            egrep -v "^$")
 
   # take the first drive as the default

--- a/scripts/install/install-get-partition
+++ b/scripts/install/install-get-partition
@@ -699,7 +699,7 @@ create_partitions() {
   fi
 
   # set the partition number on the device.
-  if [ -n "$( echo $ldrive | grep -E "cciss|ida" )" ]; then
+  if [ -n "$( echo $ldrive | grep -E "cciss|ida|nvme" )" ]; then
     # if this is a cciss
     ROOT_PARTITION=$ldrive"p1"
   else


### PR DESCRIPTION
This pull request addresses https://phabricator.vyos.net/T967, specifically in the context of NVMe (SSD) drives not being shown in the installer options under the "Install the image on?" step. It does so by updating a variety of places in the installer scripts where there is an overly specific grep that doesn't allow for a device naming structure like `nvme0n1`.

As mentioned in 7b71365, I had a difficult time finding a canonical source of device name formatting in Linux (was hoping for an RFC), but this should be pretty close to reality for NVMe drives. They're named as so:

- `nvme0`: first registered device's device controller
- `nvme0n1`: first registered device's first namespace
- `nvme0n1p1`: first registered device's first namespace's first partition

Support for `mmc` drives was discussed in https://phabricator.vyos.net/T967, but I classified it as out of scope for this pull request simply because I don't have a great way of testing that path.

It's worth pointing out that https://phabricator.vyos.net/T955 is likely a far more robust solution to this problem, but this pull request could hold over any other users who run into a similar problem as I do until the new installer is put in place.