### PR TITLE
T955: Integrating EFI into the installer

### DIFF
--- a/scripts/install/install-functions
+++ b/scripts/install/install-functions
@@ -151,7 +151,7 @@ get_drive_size () {
 # Probe hardrives not shown in /proc/partitions by default
 probe_drives () {
   # Find drives that may not be in /proc/partitions since not mounted
-  drive=$(ls /sys/block  | grep '[hsv]d.')
+  drive=$(ls /sys/block  | grep '[hsv]d.|nvme.')
 
   # now exclude all drives that are read-only
   for drive in $drive; do
@@ -174,13 +174,13 @@ select_drive () {
   local drv=''
   # list the drives in /proc/partitions.  Remove partitions and empty lines.
   # the first grep pattern looks for devices named c0d0, hda, and sda.
-  #drives=$(cat /proc/partitions | \
-  #         awk '{ if ($4!="name") { print $4 } }' | \
-  #         egrep "c[0-9]d[0-9]$|[hsv]d[a-z]$" | \
-  #         egrep -v "^$")
+  drives=$(cat /proc/partitions | \
+           awk '{ if ($4!="name") { print $4 } }' | \
+           egrep "c[0-9]d[0-9]$|[hsv]d[a-z]$|nvme[0-9]n[0-9]" | \
+           egrep -v "^$")
 
-  #should be better about finding installable drives
-  drives=$(lsblk -dn -o name -I8)
+  #this needs more testing to decide if better than above
+  #drives=$(lsblk -dn -o name -I8)
 
   # take the first drive as the default
   drv=$(echo $drives | /usr/bin/awk '{ print $1 }')

--- a/scripts/install/install-functions
+++ b/scripts/install/install-functions
@@ -174,10 +174,13 @@ select_drive () {
   local drv=''
   # list the drives in /proc/partitions.  Remove partitions and empty lines.
   # the first grep pattern looks for devices named c0d0, hda, and sda.
-  drives=$(cat /proc/partitions | \
-           awk '{ if ($4!="name") { print $4 } }' | \
-           egrep "c[0-9]d[0-9]$|[hsv]d[a-z]$" | \
-           egrep -v "^$")
+  #drives=$(cat /proc/partitions | \
+  #         awk '{ if ($4!="name") { print $4 } }' | \
+  #         egrep "c[0-9]d[0-9]$|[hsv]d[a-z]$" | \
+  #         egrep -v "^$")
+
+  #should be better about finding installable drives
+  drives=$(lsblk -dn -o name -I8)
 
   # take the first drive as the default
   drv=$(echo $drives | /usr/bin/awk '{ print $1 }')

--- a/scripts/install/install-get-partition
+++ b/scripts/install/install-get-partition
@@ -34,6 +34,8 @@ PARTITION=''
 # default file system type
 ROOT_FSTYPE='ext4'
 
+EFI_PARTITION=0
+
 warn_of_dire_consequences () {
   # Give the user a requisite warning that we are about to nuke their drive
   response=''
@@ -668,43 +670,72 @@ create_partitions() {
     echo "Error: $ldrive is only $size"MB" large.  Desired root is $root_part_size"
     exit 1
   fi
+  if [ -d /sys/firmware/efi ]; then
+       #Need room for the EFI partition.  512 is standard, but 256 is probably okay here
+       root_part_size=$((root_part_size - 256))
 
-  # Force FAT label creation
-  lecho "Creating a new disklabel on $ldrive"
-  parted -s /dev/$ldrive mklabel msdos
+       ##Do GPT/EFI Setup
+       sgdisk --zap-all /dev/$ldrive
+       # part1 = BIOS BOOT (backwards compatibility)
+       # part2 = EFI
+       # part3 = ROOT
+       sgdisk -a1 -n1:34:2047   -t1:EF02 \
+           -n2:2048:+256M -t2:EF00 \
+           -n3:0:0:+$root_part_size -t3:8300 /dev/$ldrive
+       status=$?
+       if [ "$status" != 0 ]; then
+          echo -e "Error creating primary partition on $ldrive.\nPlease see $INSTALL_LOG for more details.\nExiting..."
+          lecho "Error creating primary partition on $ldrive.\nparted /dev/$ldrive mkpart primary 0% $root_part_size\n$output"
+          exit 1
+       fi
+       # set the partition number on the device.
+       if [ -n "$( echo $ldrive | grep -E "cciss|ida" )" ]; then
+          # if this is a cciss
+          ROOT_PARTITION=$ldrive"p3"
+          EFI_PARTITION=$ldrive"p2"
+       else
+          # else... the rest of the world
+          ROOT_PARTITION=$ldrive"3"
+          EFI_PARTITION=$ldrive"2"
+       fi
+   else
+      # Force FAT label creation
+      lecho "Creating a new disklabel on $ldrive"
+      parted -s /dev/$ldrive mklabel msdos
 
-  # Make sure you can print disk info using parted
-  parted --script /dev/$ldrive p >/dev/null 2>&1
+      # Make sure you can print disk info using parted
+      parted --script /dev/$ldrive p >/dev/null 2>&1
 
-  # If we still can't, something has gone terribly wrong
-  if [ "$?" != "0" ]; then
-    echo "Unable to read disk label.  Exiting."
-    exit 1
-  fi
+      # If we still can't, something has gone terribly wrong
+      if [ "$?" != "0" ]; then
+        echo "Unable to read disk label.  Exiting."
+        exit 1
+      fi
 
-  lecho "Creating root partition on /dev/$ldrive"
+      lecho "Creating root partition on /dev/$ldrive"
 
-  # Make the root partition
-  # if optimal_io_size is empty use default of 2048s
-  if [ $(cat /sys/block/$ldrive/queue/optimal_io_size) -gt 0 ]; then
-    output=$(parted --script --align optimal /dev/$ldrive mkpart primary 0% $root_part_size)
-  else
-    output=$(parted --script --align optimal /dev/$ldrive mkpart primary 2048s $root_part_size)
-  fi
-  status=$?
-  if [ "$status" != 0 ]; then
-    echo -e "Error creating primary partition on $ldrive.\nPlease see $INSTALL_LOG for more details.\nExiting..."
-    lecho "Error creating primary partition on $ldrive.\nparted /dev/$ldrive mkpart primary 0% $root_part_size\n$output"
-    exit 1
-  fi
+      # Make the root partition
+      # if optimal_io_size is empty use default of 2048s
+      if [ $(cat /sys/block/$ldrive/queue/optimal_io_size) -gt 0 ]; then
+        output=$(parted --script --align optimal /dev/$ldrive mkpart primary 0% $root_part_size)
+      else
+        output=$(parted --script --align optimal /dev/$ldrive mkpart primary 2048s $root_part_size)
+      fi
+      status=$?
+      if [ "$status" != 0 ]; then
+        echo -e "Error creating primary partition on $ldrive.\nPlease see $INSTALL_LOG for more details.\nExiting..."
+        lecho "Error creating primary partition on $ldrive.\nparted /dev/$ldrive mkpart primary 0% $root_part_size\n$output"
+        exit 1
+      fi
 
-  # set the partition number on the device.
-  if [ -n "$( echo $ldrive | grep -E "cciss|ida" )" ]; then
-    # if this is a cciss
-    ROOT_PARTITION=$ldrive"p1"
-  else
-    # else... the rest of the world
-    ROOT_PARTITION=$ldrive"1"
+      # set the partition number on the device.
+      if [ -n "$( echo $ldrive | grep -E "cciss|ida" )" ]; then
+        # if this is a cciss
+        ROOT_PARTITION=$ldrive"p1"
+      else
+        # else... the rest of the world
+        ROOT_PARTITION=$ldrive"1"
+      fi
   fi
   # udev takes time to re-add the device file, so wait for it
   while [ ! -b "/dev/$ROOT_PARTITION" ]; do
@@ -958,7 +989,7 @@ if [ -z "$ROOT_PARTITION" ]; then
   exit 1
 fi
 
-echo "$ROOT_PARTITION_TYPE $ROOT_PARTITION $INSTALL_DRIVE" >$OUTFILE
+echo "$ROOT_PARTITION_TYPE $ROOT_PARTITION $INSTALL_DRIVE $EFI_PARTITION" >$OUTFILE
 becho 'Done!'
 exit 0
 

--- a/scripts/install/install-get-partition
+++ b/scripts/install/install-get-partition
@@ -35,6 +35,9 @@ PARTITION=''
 ROOT_FSTYPE='ext4'
 
 EFI_PARTITION=0
+if [ -d /sys/firmware/efi ]; then
+    EFI_PARTITION=1
+fi
 
 warn_of_dire_consequences () {
   # Give the user a requisite warning that we are about to nuke their drive
@@ -277,13 +280,19 @@ check_for_new_raid () {
   let root_size-=$part_start_offset
 
   for drive in $drives; do
-    echo "Creating data partition: /dev/${drive}${data_dev}"
-    create_partitions "$drive" $root_size $part_start_offset "no"
-    sfdisk --change-id /dev/$drive $data_dev 0xfd
-    # mark data partition as bootable
-    lecho "Marking /dev/$drive partition $data_dev bootable"
-    output=$(parted -s /dev/$drive set $data_dev boot on 2>&1)
-    lecho "$output"
+    create_partitions "$drive" $root_size "no"
+    if [ "$EFI_PARTITION" -eq "1" ]; then
+        #EFI moves the data parition on RAID to 3
+        data_dev=3
+        echo "Create data partition: /dev/${drive}${data_dev}"
+    else
+        echo "Creating data partition: /dev/${drive}${data_dev}"
+        sfdisk --change-id /dev/$drive $data_dev 0xfd
+        # mark data partition as bootable
+        lecho "Marking /dev/$drive partition $data_dev bootable"
+        output=$(parted -s /dev/$drive set $data_dev boot on 2>&1)
+        lecho "$output"
+    fi
   done
 
   # Must give partition device time to settle
@@ -670,7 +679,7 @@ create_partitions() {
     echo "Error: $ldrive is only $size"MB" large.  Desired root is $root_part_size"
     exit 1
   fi
-  if [ -d /sys/firmware/efi ]; then
+  if [ "$EFI_PARTITION" -eq "1" ]; then
        #Need room for the EFI partition.  512 is standard, but 256 is probably okay here
        root_part_size=$((root_part_size - 256))
 
@@ -689,15 +698,17 @@ create_partitions() {
           exit 1
        fi
        # set the partition number on the device.
-       if [ -n "$( echo $ldrive | grep -E "cciss|ida" )" ]; then
+       if [ -n "$( echo $ldrive | grep -E "cciss|ida|nvme" )" ]; then
           # if this is a cciss
           ROOT_PARTITION=$ldrive"p3"
-          EFI_PARTITION=$ldrive"p2"
+          efipart=$ldrive"p2"
        else
           # else... the rest of the world
           ROOT_PARTITION=$ldrive"3"
-          EFI_PARTITION=$ldrive"2"
+          efipart=$ldrive"2"
        fi
+       #Add the drive to the file so grub can install
+       echo $efipart >> /tmp/efiparts.tmp
    else
       # Force FAT label creation
       lecho "Creating a new disklabel on $ldrive"
@@ -729,7 +740,7 @@ create_partitions() {
       fi
 
       # set the partition number on the device.
-      if [ -n "$( echo $ldrive | grep -E "cciss|ida" )" ]; then
+      if [ -n "$( echo $ldrive | grep -E "cciss|ida|nvme" )" ]; then
         # if this is a cciss
         ROOT_PARTITION=$ldrive"p1"
       else
@@ -855,6 +866,7 @@ setup_method_auto () {
     echo -n "How big of a root partition should I create? ($ROOT_MIN"MB" - $size"MB") [$size]MB: "
     response=$(get_response "$size")
     # TODO: need to have better error checking on this value
+    # TODO: This should also probably take into account the size of the EFI partition (256MB)
     root_part_size=$(echo "$response" | sed 's/[^0-9]//g')
     if [ $root_part_size -lt $ROOT_MIN ] \
         || [ $root_part_size -gt $size ]; then
@@ -868,10 +880,12 @@ setup_method_auto () {
 
   # now take the data and create the partitions
   create_partitions "$INSTALL_DRIVE" "$root_part_size" "yes"
-  # mark data partition as bootable
-  lecho "Marking /dev/$INSTALL_DRIVE partition 1 as bootable"
-  output=$(parted -s /dev/$INSTALL_DRIVE set 1 boot on 2>&1)
-  lecho "$output"
+  if ! [ "$EFI_PARTITION" -eq "1" ]; then
+      # mark data partition as bootable
+      lecho "Marking /dev/$INSTALL_DRIVE partition 1 as bootable"
+      output=$(parted -s /dev/$INSTALL_DRIVE set 1 boot on 2>&1)
+      lecho "$output"
+  fi
   # Must give partition device time to settle
   sleep 5
 }
@@ -989,7 +1003,7 @@ if [ -z "$ROOT_PARTITION" ]; then
   exit 1
 fi
 
-echo "$ROOT_PARTITION_TYPE $ROOT_PARTITION $INSTALL_DRIVE $EFI_PARTITION" >$OUTFILE
+echo "$ROOT_PARTITION_TYPE $ROOT_PARTITION $INSTALL_DRIVE" >$OUTFILE
 becho 'Done!'
 exit 0
 

--- a/scripts/install/install-image
+++ b/scripts/install/install-image
@@ -202,6 +202,7 @@ install_new ()
 {
   local root_part=$1
   local inst_drv=$2
+  local efi_part=$3
 
   if [ ! -e "/dev/$root_part" ] || [ ! -e "/dev/$inst_drv" ]; then
     fail_exit "Invalid drive/partition ($inst_drv and $root_part)."
@@ -214,7 +215,7 @@ install_new ()
 
   # postinst operations
   if ! /opt/vyatta/sbin/install-postinst-new \
-         "$inst_drv" "$root_part" union; then
+         "$inst_drv" "$root_part" union "$efi_part"; then 
     exit 1
   fi
 }
@@ -291,13 +292,14 @@ fi
 root_part_type=''
 root_part=''
 inst_drv=''
-eval "read root_part_type root_part inst_drv <$PART_FILE" >&/dev/null
+efi_part=''
+eval "read root_part_type root_part inst_drv efi_part <$PART_FILE" >&/dev/null
 rm -f $PART_FILE >&/dev/null
 
 # handle different types
 case "$root_part_type" in
   new)
-    install_new "$root_part" "$inst_drv"
+    install_new "$root_part" "$inst_drv" "$efi_part"
     exit 0
     ;;
   union|old)

--- a/scripts/install/install-image
+++ b/scripts/install/install-image
@@ -202,7 +202,6 @@ install_new ()
 {
   local root_part=$1
   local inst_drv=$2
-  local efi_part=$3
 
   if [ ! -e "/dev/$root_part" ] || [ ! -e "/dev/$inst_drv" ]; then
     fail_exit "Invalid drive/partition ($inst_drv and $root_part)."
@@ -215,7 +214,7 @@ install_new ()
 
   # postinst operations
   if ! /opt/vyatta/sbin/install-postinst-new \
-         "$inst_drv" "$root_part" union "$efi_part"; then 
+         "$inst_drv" "$root_part" union; then 
     exit 1
   fi
 }
@@ -292,14 +291,13 @@ fi
 root_part_type=''
 root_part=''
 inst_drv=''
-efi_part=''
-eval "read root_part_type root_part inst_drv efi_part <$PART_FILE" >&/dev/null
+eval "read root_part_type root_part inst_drv <$PART_FILE" >&/dev/null
 rm -f $PART_FILE >&/dev/null
 
 # handle different types
 case "$root_part_type" in
   new)
-    install_new "$root_part" "$inst_drv" "$efi_part"
+    install_new "$root_part" "$inst_drv" 
     exit 0
     ;;
   union|old)

--- a/scripts/install/install-postinst-new
+++ b/scripts/install/install-postinst-new
@@ -20,6 +20,8 @@ INSTALL_DRIVE=$1
 ROOT_PARTITION=$2
 # install type: "union" or "old"
 INSTALL_TYPE=$3
+# EFI partition.  0 or partition
+EFI_PARTITION=$4
 
 # Default user
 DEFAULT_USER=vyos
@@ -122,20 +124,29 @@ install_grub () {
   # members.
   
   progress_indicator start
-  
-  if [[ $grub_inst_drv == "md raid" ]]; then
-    for slave in $raid_slaves; do
-      grub_inst_drv=${slave:0:3}
-      output=$(grub-install --no-floppy --recheck --root-directory=$grub_root \
-          /dev/$grub_inst_drv 2>&1)
-      lecho "$output"
-    done
-  else
-    output=$(grub-install --no-floppy --recheck --root-directory=$grub_root \
-        /dev/$grub_inst_drv 2>&1)
-    lecho "$output"
+
+  #TODO EFI needs to go on every disk
+  if [ -b /dev/$EFI_PARTITION ]; then
+     mkdosfs -F 32 -n EFI /dev/$EFI_PARTITION
+     mkdir -p $grub_root/boot/efi
+     mount /dev/$EFI_PARTITION $grub_root/boot/efi
+     output=$(grub-install --no-floppy --recheck --target=x86_64-efi --root-directory=$grub_root --efi-directory=$grub_root/boot/efi --bootloader-id="VyOS")
+     umount $grub_root/boot/efi
+  else   
+      if [[ $grub_inst_drv == "md raid" ]]; then
+        for slave in $raid_slaves; do
+          grub_inst_drv=${slave:0:3}
+          output=$(grub-install --no-floppy --recheck --root-directory=$grub_root \
+              /dev/$grub_inst_drv 2>&1)
+          lecho "$output"
+        done
+      else
+        output=$(grub-install --no-floppy --recheck --root-directory=$grub_root \
+            /dev/$grub_inst_drv 2>&1)
+        lecho "$output"
+      fi
   fi
-  
+      
   progress_indicator stop
 
   output=$(/opt/vyatta/sbin/vyatta-grub-setup $grub_setup_args \

--- a/scripts/install/install-postinst-new
+++ b/scripts/install/install-postinst-new
@@ -20,8 +20,8 @@ INSTALL_DRIVE=$1
 ROOT_PARTITION=$2
 # install type: "union" or "old"
 INSTALL_TYPE=$3
-# EFI partition.  0 or partition
-EFI_PARTITION=$4
+# For passing into vyatta-grub-setup
+EFI_PARTITION=0
 
 # Default user
 DEFAULT_USER=vyos
@@ -125,13 +125,33 @@ install_grub () {
   
   progress_indicator start
 
-  #TODO EFI needs to go on every disk
-  if [ -b /dev/$EFI_PARTITION ]; then
-     mkdosfs -F 32 -n EFI /dev/$EFI_PARTITION
+ if [ -f "/tmp/efiparts.tmp" ]; then
+     EFI_PARTITION=1
      mkdir -p $grub_root/boot/efi
-     mount /dev/$EFI_PARTITION $grub_root/boot/efi
-     output=$(grub-install --no-floppy --recheck --target=x86_64-efi --root-directory=$grub_root --efi-directory=$grub_root/boot/efi --bootloader-id="VyOS")
-     umount $grub_root/boot/efi
+     readarray parts < /tmp/efiparts.tmp
+     part_length=${#parts[@]}
+     bootloader_name="VyOS"
+     I=0
+     for part in "${parts[@]}"
+     do
+	#Name the bootloaders something different if we have a RAID
+         if [ "$part_length" -gt "1" ]; then
+             bootloader_name="VyOS (RAID disk $I)"
+             ((I++))
+         fi
+         mkdosfs -F 32 -n EFI /dev/$part
+         mount /dev/$part $grub_root/boot/efi
+         output=$(grub-install --no-floppy --recheck --target=x86_64-efi --root-directory=$grub_root --efi-directory=$grub_root/boot/efi --bootloader-id="$bootloader_name")
+         umount $grub_root/boot/efi
+         ##TODO DO we need these to be in fstab??
+         #
+         #This is what I've used in the past
+         #if [ $I -gt 0 ]; then
+         #    RAIDPART="#"
+         #fi
+         #echo "${RAIDPART}PARTUUID=$(blkid -s PARTUUID -o value $part) /boot/efi vfat defaults 0 1" >> /etc/fstab
+     done
+     rm /tmp/efiparts.tmp
   else   
       if [[ $grub_inst_drv == "md raid" ]]; then
         for slave in $raid_slaves; do
@@ -150,7 +170,7 @@ install_grub () {
   progress_indicator stop
 
   output=$(/opt/vyatta/sbin/vyatta-grub-setup $grub_setup_args \
-             "$ROOT_PARTITION" '' $grub_root 2>&1)
+             "$ROOT_PARTITION" '' $grub_root "$EFI_PARTITION" 2>&1)
   ret=$?
   lecho "$output"
   if [ $ret == 0 ]; then

--- a/scripts/vyatta-grub-setup
+++ b/scripts/vyatta-grub-setup
@@ -156,7 +156,8 @@ fi
     echo -e "serial --unit=0 --speed=9600"
     echo "terminal_output --append serial"
 
-    if [ -b /dev/$EFI_PARTITION ]; then
+    # EFI needs a few extra modules
+    if [ "$EFI_PARTITION" -eq "1" ]; then
 	echo -e "insmod efi_gop"
 	echo -e "insmod efi_uga"
     fi

--- a/scripts/vyatta-grub-setup
+++ b/scripts/vyatta-grub-setup
@@ -54,6 +54,7 @@ shift `expr $OPTIND - 1`
 ROOT_PARTITION="$1"
 GRUB_OPTIONS="$2"
 ROOTFSDIR="$3"
+EFI_PARTITION="$4"
 
 [ "$ROOT_PARTITION" ] || exit 1
 
@@ -154,6 +155,11 @@ fi
     # set serial console options
     echo -e "serial --unit=0 --speed=9600"
     echo "terminal_output --append serial"
+
+    if [ -b /dev/$EFI_PARTITION ]; then
+	echo -e "insmod efi_gop"
+	echo -e "insmod efi_uga"
+    fi
 
     if [ ${ROOT_PARTITION:0:2} = "md" ]; then
 	uuid_root_disk=`/sbin/tune2fs -l /dev/${root_disk}1 | grep UUID | awk '{print $3}'`


### PR DESCRIPTION
Additional Packages: 
`gdisk` (GPT partitioning), `dosfstools` (managing/formatting EFI partition)

Caveats:   
Needs the hybrid ISO that's being worked on.  That should also have `grub-efi` instead of `grub2` and `grub-pc`.  

As of right now these changes should be functional, but won't execute because the `[ -d /sys/firmware/efi ]` will never be true.  

