### PR TITLE
T1045: static route dhcp-interface: check for ip in response

### DIFF
--- a/scripts/vyatta-dhcp-helper.pl
+++ b/scripts/vyatta-dhcp-helper.pl
@@ -22,9 +22,12 @@ sub get_dhcp_router {
     my $router = `grep new_routers= $lease | cut -d"'" -f2`;
     my @r = split(/,/, $router);
     $router = $r[0];
-    if ($router eq "") {
+    # Make sure the result looks like a IP
+    if ($router !~ /\d+\.\d+\.\d+\.\d+/) {
         return "127.0.0.1";
     }
+    # Remove trailing newlines
+    $router =~ s/\n$//;
     return $router;
 }
 


### PR DESCRIPTION
Checks done to verify a dhcp-lease on the interface is updated to look for a
ip-address like response from dhclient before returning an error.

This fixes the error where a newline was enough to make the checks fail..

Updated to also make sure no newline is returned after the address to make
sure commands using adresses from this script is not cut in half by the newline,
and to be in line with the syntax on all errors. (no newline at the end)