### PR TITLE
T1023

### DIFF
--- a/scripts/install/install-get-partition
+++ b/scripts/install/install-get-partition
@@ -34,11 +34,6 @@ PARTITION=''
 # default file system type
 ROOT_FSTYPE='ext4'
 
-EFI_PARTITION=0
-if [ -d /sys/firmware/efi ]; then
-    EFI_PARTITION=1
-fi
-
 warn_of_dire_consequences () {
   # Give the user a requisite warning that we are about to nuke their drive
   response=''
@@ -281,7 +276,7 @@ check_for_new_raid () {
 
   for drive in $drives; do
     create_partitions "$drive" $root_size "no"
-    if [ "$EFI_PARTITION" -eq "1" ]; then
+    if [ -d /sys/firmware/efi ]; then
         #EFI moves the data parition on RAID to 3
         data_dev=3
         echo "Create data partition: /dev/${drive}${data_dev}"
@@ -679,7 +674,7 @@ create_partitions() {
     echo "Error: $ldrive is only $size"MB" large.  Desired root is $root_part_size"
     exit 1
   fi
-  if [ "$EFI_PARTITION" -eq "1" ]; then
+  if [ -d /sys/firmware/efi ]; then
        #Need room for the EFI partition.  512 is standard, but 256 is probably okay here
        root_part_size=$((root_part_size - 256))
 
@@ -880,7 +875,7 @@ setup_method_auto () {
 
   # now take the data and create the partitions
   create_partitions "$INSTALL_DRIVE" "$root_part_size" "yes"
-  if ! [ "$EFI_PARTITION" -eq "1" ]; then
+  if ! [ -d /sys/firmware/efi ]; then
       # mark data partition as bootable
       lecho "Marking /dev/$INSTALL_DRIVE partition 1 as bootable"
       output=$(parted -s /dev/$INSTALL_DRIVE set 1 boot on 2>&1)

--- a/scripts/install/install-postinst-new
+++ b/scripts/install/install-postinst-new
@@ -20,8 +20,6 @@ INSTALL_DRIVE=$1
 ROOT_PARTITION=$2
 # install type: "union" or "old"
 INSTALL_TYPE=$3
-# For passing into vyatta-grub-setup
-EFI_PARTITION=0
 
 # Default user
 DEFAULT_USER=vyos
@@ -130,7 +128,6 @@ install_grub () {
      dpkg -r grub-pc grub2 >&/dev/null
      # Install grub-efi packages
      dpkg -i /usr/share/vyos/packages/grub-efi*.deb >&/dev/null
-     EFI_PARTITION=1
      mkdir -p $grub_root/boot/efi
      readarray parts < /tmp/efiparts.tmp
      part_length=${#parts[@]}
@@ -145,7 +142,7 @@ install_grub () {
          fi
          mkdosfs -F 32 -n EFI /dev/$part >&/dev/null
          mount /dev/$part $grub_root/boot/efi
-         output=$(grub-install --no-floppy --recheck --target=x86_64-efi --root-directory=$grub_root --efi-directory=$grub_root/boot/efi --bootloader-id="$bootloader_name" 2>&1)
+         output=$(grub-install --no-floppy --recheck --target=x86_64-efi --force-extra-removable --root-directory=$grub_root --efi-directory=$grub_root/boot/efi --bootloader-id="$bootloader_name" 2>&1)
          umount $grub_root/boot/efi
          ##TODO DO we need these to be in fstab??
          #
@@ -174,7 +171,7 @@ install_grub () {
   progress_indicator stop
 
   output=$(/opt/vyatta/sbin/vyatta-grub-setup $grub_setup_args \
-             "$ROOT_PARTITION" '' $grub_root "$EFI_PARTITION" 2>&1)
+             "$ROOT_PARTITION" '' $grub_root 2>&1)
   ret=$?
   lecho "$output"
   if [ $ret == 0 ]; then

--- a/scripts/vyatta-grub-setup
+++ b/scripts/vyatta-grub-setup
@@ -54,7 +54,6 @@ shift `expr $OPTIND - 1`
 ROOT_PARTITION="$1"
 GRUB_OPTIONS="$2"
 ROOTFSDIR="$3"
-EFI_PARTITION="$4"
 
 [ "$ROOT_PARTITION" ] || exit 1
 
@@ -157,7 +156,7 @@ fi
     echo "terminal_output --append serial"
 
     # EFI needs a few extra modules
-    if [ "$EFI_PARTITION" -eq "1" ]; then
+    if [ -d /sys/firmware/efi ]; then
 	echo -e "insmod efi_gop"
 	echo -e "insmod efi_uga"
     fi


### PR DESCRIPTION
Adds the requested option from T1023.  That option forces grub to install the EFI boot file to a universal location for all UEFI bootloaders and removable media.

Cleaned up a bit of the EFI cruft that was unnecessary.