### PR TITLE
T1109 - Add option for enabling multipath ecmp L4 hashing and dead-ne…

### DIFF
--- a/templates/system/multipath/dead-neighbor-detection/node.def
+++ b/templates/system/multipath/dead-neighbor-detection/node.def
@@ -1,0 +1,5 @@
+help: Enable multipath dead neighbor detection
+create:
+  sudo sh -c "echo 1 > /proc/sys/net/ipv4/fib_multipath_use_neigh"
+delete:
+  sudo sh -c "echo 0 > /proc/sys/net/ipv4/fib_multipath_use_neigh"

--- a/templates/system/multipath/layer4-hasing/node.def
+++ b/templates/system/multipath/layer4-hasing/node.def
@@ -1,0 +1,7 @@
+help: Enable Layer4 ECMP Hashing
+create:
+  sudo sh -c "echo 1 > /proc/sys/net/ipv4/fib_multipath_hash_policy"
+  sudo sh -c "echo 1 > /proc/sys/net/ipv6/fib_multipath_hash_policy" 
+delete: 
+  sudo sh -c "echo 0 > /proc/sys/net/ipv4/fib_multipath_hash_policy"
+  sudo sh -c "echo 0 > /proc/sys/net/ipv6/fib_multipath_hash_policy" 

--- a/templates/system/multipath/node.def
+++ b/templates/system/multipath/node.def
@@ -1,0 +1,1 @@
+help: Multipath ECMP Settings


### PR DESCRIPTION
…ighbor-detection

After kernel v4.17 options are added to enable Layer 4 hashing inside the linux kernel.
As we are running 4.19 these options are available to us, bit the ui is missing options to configure it.

new options are:
set system multipath layer4-hashing
set system multipath dead-neighbor-detection

options set in sysstl:
set system multipath layer4-hashing:
    net.ipv4.fib_multipath_hash_policy
    net.ipv6.fib_multipath_hash_policy
    both set to 1 when enabled and 0 when disabled

set system multipath dead-neighbor-detection:
    net.ipv4.fib_multipath_use_neigh
    set to 1 when enabled and 0 when disabled