### PR TITLE
T1107 Added requested option to grub

### DIFF
--- a/scripts/vyatta-grub-setup
+++ b/scripts/vyatta-grub-setup
@@ -154,6 +154,7 @@ fi
     # set serial console options
     echo -e "serial --unit=0 --speed=9600"
     echo "terminal_output --append serial"
+    echo "terminal_input serial console"
 
     # EFI needs a few extra modules
     if [ -d /sys/firmware/efi ]; then


### PR DESCRIPTION
Adds the requested "terminal_input serial console" option to the grub.cfg.  In testing, doesn't seem to impact non-serial connections.