### PR TITLE
T1120: Add rootdelay=5 by default in grub.cfg

### DIFF
--- a/scripts/vyatta-grub-setup
+++ b/scripts/vyatta-grub-setup
@@ -60,9 +60,9 @@ ROOTFSDIR="$3"
 # Grub options
 if [ "$GRUB_OPTIONS" ]
 then
-	GRUB_OPTIONS="$GRUB_OPTIONS quiet"
+	GRUB_OPTIONS="$GRUB_OPTIONS quiet rootdelay=5"
 else
-	GRUB_OPTIONS=quiet
+	GRUB_OPTIONS="quiet rootdelay=5"
 fi
 
 # Path to standalone root password reset script
@@ -103,7 +103,7 @@ else
 fi
 
 if eval "$UNION"; then
-    GRUB_OPTIONS="boot=live quiet vyos-union=/boot/$livedir"
+    GRUB_OPTIONS="boot=live quiet rootdelay=5 vyos-union=/boot/$livedir"
     union_xen_kernel_version=$(ls $ROOTFSDIR/boot/$livedir/vmlinuz*-xen* \
                                  2>/dev/null \
                                | awk -F/ '{ print $6 }' \


### PR DESCRIPTION
Let disks settle to workaround issue with MD array not being detected.