### PR TITLE
 T1499: Allow for usage of systemd interface mappings

### DIFF
--- a/sysconf/netdevice
+++ b/sysconf/netdevice
@@ -2,6 +2,10 @@
 lo	loopback
 eth	ethernet
 lan	ethernet
+eno	ethernet
+ens	ethernet
+enp	ethernet
+enx	ethernet
 ifb	input
 peth	pseudo-ethernet
 br	bridge

--- a/templates/interfaces/ethernet/node.def
+++ b/templates/interfaces/ethernet/node.def
@@ -4,7 +4,8 @@ type: txt
 help: Ethernet interface name
 allowed: /opt/vyatta/sbin/vyatta-interfaces.pl --show=ethernet
 val_help: <ethN>; Ethernet interface name
-syntax:expression: pattern $VAR(@) "^(eth|lan)[0-9]+$" \
+          <en[ospx]N; Ethernet interface name
+syntax:expression: pattern $VAR(@) "^(eth|lan|eno|ens|enp|enx)[0-9]+/S+$" \
 		   ; "interface ethernet $VAR(@): not a valid name"
 
 syntax:expression: exec \

--- a/templates/interfaces/ethernet/node.def
+++ b/templates/interfaces/ethernet/node.def
@@ -5,7 +5,7 @@ help: Ethernet interface name
 allowed: /opt/vyatta/sbin/vyatta-interfaces.pl --show=ethernet
 val_help: <ethN>; Ethernet interface name
           <en[ospx]N; Ethernet interface name
-syntax:expression: pattern $VAR(@) "^(eth|lan|eno|ens|enp|enx)[0-9]+/S+$" \
+syntax:expression: pattern $VAR(@) "^((eth|lan)[0-9]+|(eno|ens|enp|enx).+)$" \
 		   ; "interface ethernet $VAR(@): not a valid name"
 
 syntax:expression: exec \

--- a/templates/interfaces/tunnel/node.tag/dhcp-interface/node.def
+++ b/templates/interfaces/tunnel/node.tag/dhcp-interface/node.def
@@ -2,7 +2,7 @@ type: txt
 help: DHCP interface that supplies the local IP address for this tunnel
 allowed:
         local -a array ;
-        array=( /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
+        array=( /var/lib/dhcp/en* /var/lib/dhcp/eth* /var/lib/dhcp/br* /var/lib/dhcp/bond* ) ;
         echo  -n ${array[@]##*/}
 create:
         sudo /opt/vyatta/sbin/vyatta-update-tunnel.pl --interface=$VAR(@) --tunnel=$VAR(../@) --option=create

--- a/templates/system/ipv6/strict-dad/node.def
+++ b/templates/system/ipv6/strict-dad/node.def
@@ -21,7 +21,7 @@ create:
 delete: 
     sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/all/accept_dad"
     sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/default/accept_dad"
-    for ifname in /sys/class/net/eth* ; do
+    for ifname in /sys/class/net/eth* /sys/class/net/en* ; do
 	if [ -d $ifname ]; then
 	    ifname=${ifname#/sys/class/net/}
        	    sudo sh -c "echo 1 > /proc/sys/net/ipv6/conf/$ifname/accept_dad"


### PR DESCRIPTION
This PR allows the use of systemd named interfaces for ethernet.
this might get used when migrating over to buster with systemd default mappings. 