### PR TITLE
net.ipv6.route.max_size = 262144

### DIFF
--- a/scripts/rl-system.init
+++ b/scripts/rl-system.init
@@ -136,7 +136,7 @@ set_ipv6_params ()
     echo 1 >/proc/sys/net/ipv6/conf/all/forwarding
 
     # Increase route table limit
-    echo 32768 >/proc/sys/net/ipv6/route/max_size
+    echo 262144 >/proc/sys/net/ipv6/route/max_size
 
     # These values all should be disabled
     for p in accept_source_route accept_redirects


### PR DESCRIPTION
The IPv6 DFZ is now approaching 80k routes. Time to bump VyOS's default up, because otherwise it is a nasty surprise that's tricky to debug.

(see also [T1514](https://phabricator.vyos.net/T1514))