### PR TITLE
[Interface, OpenVPN]: T1704: New interface version 3, because of OpenVPN config syntax change

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -116,7 +116,7 @@ curver_DATA += cfg-version/l2tp@1
 curver_DATA += cfg-version/pptp@1
 curver_DATA += cfg-version/ntp@1
 curver_DATA += cfg-version/webproxy@2
-curver_DATA += cfg-version/interfaces@2
+curver_DATA += cfg-version/interfaces@3
 curver_DATA += cfg-version/dns-forwarding@2
 curver_DATA += cfg-version/vyos-accel-ppp@2
 


### PR DESCRIPTION
This PR is dependent on https://github.com/vyos/vyos-1x/pull/146