### PR TITLE
Fix rootdev regex to support mmcblk devices

### DIFF
--- a/scripts/install/install-get-partition
+++ b/scripts/install/install-get-partition
@@ -363,7 +363,7 @@ select_partition () {
     if [ ${part:0:2} = "md" ]; then
       parttype="RAID"
     else
-      rootdev=$(echo $part | sed 's/[0-9]//g')
+      rootdev=$(echo $part | sed -E 's/p?[0-9]$//g')
       parttype=$(fdisk -l /dev/$rootdev | grep $part | grep Linux)
     fi
     if [ -n "$parttype" ]; then


### PR DESCRIPTION
mmc/nvme devices normally contain numbers (`mmcblk0`, `nvme0n1`, etc).
The current image installer fails on these since the sed expression removes all numbers. With this modification I got it working.
This fixes that (note that there is an unlikely edge-case here too if e.g. `sdp` is the root device).