### PR TITLE
Fix ipv6 disable not working

### DIFF
--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -269,6 +269,9 @@ if [ -e "$DEF_GRUB" ]; then
   sed -i "s/menuentry \"VyOS.*(/menuentry \"VyOS $NEWNAME (/" $def_grub_vers
   sed -i "s/menuentry \"Lost password change.*(/menuentry \"Lost password change $NEWNAME (/" $def_grub_vers
   sed -i "sX/boot/[A-Za-z0-9\.\-]*X/boot/${NEWNAME}Xg" $def_grub_vers
+  if [ -f /etc/modprobe.d/vyos_disable_ipv6.conf ]; then
+    sed -i "/^[[:space:]]*linux / {/ipv6.disable=/! s/$/ ipv6.disable=1/}" $def_grub_vers
+  fi
 
   old_grub_cfg=$BOOT_DIR/grub/grub.cfg
   new_grub_cfg=/tmp/grub.cfg.$$

--- a/scripts/vyatta-grub-setup
+++ b/scripts/vyatta-grub-setup
@@ -102,8 +102,13 @@ else
       default_console=0
 fi
 
+IPV6=
+if [ -f /etc/modprobe.d/vyos_disable_ipv6.conf ]; then
+    IPV6="ipv6.disable=1"
+fi
+
 if eval "$UNION"; then
-    GRUB_OPTIONS="boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/$livedir"
+    GRUB_OPTIONS="boot=live quiet rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/$livedir $IPV6"
     union_xen_kernel_version=$(ls $ROOTFSDIR/boot/$livedir/vmlinuz*-xen* \
                                  2>/dev/null \
                                | awk -F/ '{ print $6 }' \
@@ -124,7 +129,7 @@ else
         echo "Unable to read filesystem UUID.  Exiting."
         exit 1
     else
-        GRUB_OPTIONS="$GRUB_OPTIONS root=UUID=$uuid ro"
+        GRUB_OPTIONS="$GRUB_OPTIONS $IPV6 root=UUID=$uuid ro"
     fi
 fi
 


### PR DESCRIPTION
IPV6 is build directly into the kernel. So, it's not loaded by modprobe, so the modprobe configuration is not involved.

Builtin module parameters can be configured through kernel command line.

grub setup scripts add the parameters to grub