### PR TITLE
conf-mode: T2423: Loadkey add insecure option

### DIFF
--- a/scripts/vyatta-load-user-key.pl
+++ b/scripts/vyatta-load-user-key.pl
@@ -61,7 +61,7 @@ sub geturl {
     check_http($url)
 	if ($proto eq 'http');
 
-    my $cmd = "curl -#";
+    my $cmd = "curl --insecure -#";
 
     # Handle user@host syntax which curl doesn't do
     if ($proto eq 'scp') {


### PR DESCRIPTION
Loadkey dont work.
```
curl: (60) SSL peer certificate or SSH remote key was not OK
More details here: https://curl.haxx.se/docs/sslcerts.html
```
Workaround add an insecure option for loadkey.