### PR TITLE
T2765: arm: vyatta-cfg-system is dependent on a amd64 only package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -47,7 +47,7 @@ Depends:  adduser,
  libpam-cap,
  efibootmgr,
  libefivar0 | libefivar1,
- grub-efi-amd64-bin,
+ grub-efi-amd64-bin [amd64],
  dosfstools,
  gdisk,
  vyatta-biosdevname


### PR DESCRIPTION
The vyatta-cfg-system package is dependent on the grub-efi-amd64-bin package to be installed.
This makes it unable to be built for any other platform as the package is amd64 only.

This commit changes the dependency to be a amd64 dependency only, thouse it will not be present on other architectures