### PR TITLE
cfg-system: T2902: Fix regex that doesnt allow X in image name

### DIFF
--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -268,7 +268,7 @@ if [ -e "$DEF_GRUB" ]; then
   cp $DEF_GRUB $def_grub_vers
   sed -i "s/menuentry \"VyOS.*(/menuentry \"VyOS $NEWNAME (/" $def_grub_vers
   sed -i "s/menuentry \"Lost password change.*(/menuentry \"Lost password change $NEWNAME (/" $def_grub_vers
-  sed -i "sX/boot/[A-Za-z0-9\.\-]*X/boot/${NEWNAME}Xg" $def_grub_vers
+  sed -i "s%/boot/[A-Za-z0-9\.\-]*%/boot/${NEWNAME}%g" $def_grub_vers
 
   old_grub_cfg=$BOOT_DIR/grub/grub.cfg
   new_grub_cfg=/tmp/grub.cfg.$$


### PR DESCRIPTION
Using the special characters "%" in the regular expression, which cannot be contained in the image name.
