### PR TITLE
image: T2992: automatically verify sha256 checksum on ISO download

### DIFF
--- a/scripts/install/install-image
+++ b/scripts/install/install-image
@@ -147,8 +147,39 @@ fetch_iso_by_url ()
         echo "Download of $NEW_ISO failed"
         exit 1
     fi
-
     echo "ISO download succeeded."
+
+    echo "Checking SHA256 (256-bit) checksum..."
+    ip vrf exec $VRF curl -L -H "User-Agent: VyOS/$vyos_version" $AUTH -f -o ${filename}.sha256 ${NEW_ISO}.sha256
+    if [ $? -ne 0 ]; then
+        echo "Unable to fetch SHA256 checksum file."
+        echo -n "Do you want to continue without checksum verification? (yes/no) [yes] "
+
+        response=$(get_response "Yes" "Yes No Y N")
+        if [ "$response" == "no" ] || [ "$response" == "n" ]; then
+            rm -f $filename
+            fail_exit 'OK.  Installation will not be performed.'
+        fi
+        # In case signature file was partially downloaded...
+        rm -f ${filename}.sha256
+    fi
+    if [ -e ${filename}.sha256 ]; then
+        echo "Found it.  Verifying checksum..."
+        # save our current working directory
+        cwd=$(pwd)
+        # checksum validation must be performed in the download directory because
+        # of the relative path inside the checksum file
+        cd ${TEMP_DIR}
+        sha256sum --check --quiet ${NEW_ISO##*/}.sha256
+        if [ $? -ne 0 ]; then
+            echo "Signature check FAILED."
+            fail_exit 'Installation will not be performed.'
+        else
+            echo "SHA256 checksum valid."
+        fi
+        # restore old working directory
+        cd $cwd
+    fi
 
     echo "Checking for digital signature file..."
     ip vrf exec $VRF curl -L -H "User-Agent: VyOS/$vyos_version" $AUTH -f -o ${filename}.asc ${NEW_ISO}.asc


### PR DESCRIPTION
I'm wondering why downloading an invalid ISO file was not cought by the integrated MD5 check `Checking MD5 checksums of files on the ISO image...OK.`?

## Good:
```
vyos@vyos:~$ add system image http://foo.com/vyos-1.3-rolling-202010180826-amd64.iso
Trying to fetch ISO file from http://foo.com/vyos-1.3-rolling-202010180826-amd64.iso
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  309M  100  309M    0     0  25.1M      0  0:00:12  0:00:12 --:--:-- 25.2M
ISO download succeeded.
Checking SHA256 (256-bit) checksum...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   106  100   106    0     0  26500      0 --:--:-- --:--:-- --:--:-- 26500
Found it.  Verifying checksum...
SHA256 checksum valid.
Checking for digital signature file...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
Unable to fetch digital signature file.
Do you want to continue without signature check? (yes/no) [yes]
```

## Bad:
```
vyos@vyos:~$ add system image http://foo.com/vyos-1.3-rolling-202010180826-amd64.iso
Trying to fetch ISO file from http://foo.com/vyos-1.3-rolling-202010180826-amd64.iso
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  309M  100  309M    0     0  25.8M      0  0:00:11  0:00:11 --:--:-- 25.8M
ISO download succeeded.
Checking SHA256 (256-bit) checksum...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   106  100   106    0     0   9636      0 --:--:-- --:--:-- --:--:--  9636
Found it.  Verifying checksum...
vyos-1.3-rolling-202010180826-amd64.iso: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
Signature check FAILED.
Installation will not be performed.
Exiting...
```