### PR TITLE
vyatta-cfg: T2713: Return original permissions for config-auth files

### DIFF
--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -222,6 +222,10 @@ if [ $space_avail -gt $space_needed_configdata ]; then
 
       chgrp -R vyattacfg $ndir
       chmod -R 775 $ndir
+
+      # Return original permissions for private files in config/auth. T2713
+      rsync -a ${VYATTA_NEW_CFG_DIR}/auth/ ${ndir}/auth/
+
     fi
   done
 else


### PR DESCRIPTION
Return original permissions for /config/auth/* when updating the system