### PR TITLE
bgp: T1711: bump bgp config version 0 -> 1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -105,6 +105,7 @@ curver_DATA += cfg-version/nat66@1
 curver_DATA += cfg-version/quagga@9
 curver_DATA += cfg-version/vrf@2
 curver_DATA += cfg-version/isis@1
+curver_DATA += cfg-version/bgp@1
 
 cpiop = find  . ! -regex '\(.*~\|.*\.bak\|.*\.swp\|.*\#.*\#\)' -print0 | \
   cpio -0pd


### PR DESCRIPTION
Must be merged together with https://github.com/vyos/vyos-1x/pull/793