### PR TITLE
migration: T2838: fix parsing of quoted config value for hw-id

### DIFF
--- a/scripts/vyatta_net_name
+++ b/scripts/vyatta_net_name
@@ -55,7 +55,7 @@ sub get_hwid_from_children {
     my $children = shift;
 
     foreach my $attr (@$children) {
-	next unless ($attr->{'name'} =~ /^hw-id ([0-9a-f:]+)/);
+	next unless (($attr->{'name'} =~ /^hw-id ([0-9a-f:]+)/) || ($attr->{'name'} =~ /^hw-id "([0-9a-f:]+)"/));
 	return $1;
     }
 


### PR DESCRIPTION
configtree places values in quotes; consequently, during migration, unquoted values in the config file will be quoted. This is reasonable, and in certainly cases, necessary; however, 'vyatta_net_name' does not consider this when parsing for hw-id, and consequently will re-write the hw-id in the interface block, leading to a redundancy. This is a quick (and likely temporary) fix for that bug.