### PR TITLE
ipv6: T3394: Fix for del ipv6 address normalize

### DIFF
--- a/scripts/vyatta-address
+++ b/scripts/vyatta-address
@@ -35,7 +35,10 @@ case $1 in
             ip_address=$(ip a s dev $2 | grep "inet $ip" | awk '{print $2}')
         elif [[ "$3" = "dhcpv6" ]]; then
             lease_file=/var/lib/dhcp/dhclient_v6_"$(echo $2 | sed -e 's/\./_/')".leases;
-            ip_address=$(sed -n 's/^\s\s\s\siaaddr\s\(.*\)\s{/\1/p' $lease_file | sed -n '$p');
+            #ip_address=$(sed -n 's/^\s\s\s\siaaddr\s\(.*\)\s{/\1/p' $lease_file | sed -n '$p');
+            # T1053 T3394 we need IP/prefix for normalize-ip to function
+            ipv6=$(sed -n 's/^\s\s\s\siaaddr\s\(.*\)\s{/\1/p' $lease_file | sed -n '$p');
+            ip_address=$(ip -6 a s dev $2 | grep "inet6 $ipv6" | awk '{print $2}')
         else
             ip_address=$3;
         fi


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a commend and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->
Normalize IP expected ip/ipv6/dhcp/dhcpv6 address with prefix [normalize-ip](https://github.com/vyos/vyos-1x/blob/9fb7b7560ea8907f4bcae2f44e7373fb2eb99606/src/system/normalize-ip#L32)
When we delete address from interface, we send the ipv6(dhcp) address without prefix. [ip-addr](https://github.com/vyos/vyatta-cfg-system/blob/165e56e88763c40f13e6ef77f5df1c888fdfb899/scripts/vyatta-address#L38) and [ipv6-norm](https://github.com/vyos/vyatta-cfg-system/blob/165e56e88763c40f13e6ef77f5df1c888fdfb899/scripts/vyatta-address#L47)

ie
```
vyos@r2-lts# /usr/libexec/vyos/system/normalize-ip 2001:db8::191
Traceback (most recent call last):
  File "/usr/libexec/vyos/system/normalize-ip", line 32, in <module>
    address_string, prefix_length = re.match(r'(.+)/(.+)', sys.argv[1]).groups()
AttributeError: 'NoneType' object has no attribute 'groups'
[edit]
vyos@r2-lts#
```

That fix adds ipv6 prefix for normalized-ip for dhcpv6 checks

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- All submitted PRs must be linked to a Task on Phabricator. -->
* https://phabricator.vyos.net/T3394

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
ipv6
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
Assign both ipv4 + ipv6 addresses by dhcp
And delete IP address.
We shouldn't see any errros.
```
set interfaces ethernet eth1 address 'dhcp'

set interfaces ethernet eth1 address 'dhcpv6'
commit
sudo sleep 5
del interfaces ethernet eth1 address
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
