### PR TITLE
pki: T3642: Migrate rsa-keys to PKI configuration

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,7 +82,7 @@ curver_DATA += cfg-version/bgp@1
 curver_DATA += cfg-version/policy@1
 curver_DATA += cfg-version/conntrack@2
 curver_DATA += cfg-version/conntrack-sync@2
-curver_DATA += cfg-version/ipsec@7
+curver_DATA += cfg-version/ipsec@8
 
 cpiop = find  . ! -regex '\(.*~\|.*\.bak\|.*\.swp\|.*\#.*\#\)' -print0 | \
   cpio -0pd


### PR DESCRIPTION
Requirement for `vpn rsa-keys` migration to PKI configuration.