### PR TITLE
T3865: loadkey command help text missing escape sequence

### DIFF
--- a/scripts/vyatta-load-user-key.pl
+++ b/scripts/vyatta-load-user-key.pl
@@ -159,7 +159,7 @@ sub getkeys {
 
 print "Warning: `loadkey' command has been deprecated and will be removed in a future version.\n";
 print "Instead, use the op-mode command `generate public-key-command' to generate commands for manual addition:\n";
-print "$ generate public-key-command name <username> path <path-or-url>\n\n";
+print "\$ generate public-key-command name <username> path <path-or-url>\n\n";
 
 die "Incorrect number of arguments, expect\n",
     " loadkey user filename|url\n"


### PR DESCRIPTION
## Change Summary

After `T3506` backslash(`\`) is missing, throwing the following error:

```
vyos@vyos# loadkey vyos /home/vyos/.ssh/id_rsa.pub
Global symbol "$generate" requires explicit package name (did you forget to declare "my $generate"?) at /opt/vyatta/sbin/vyatta-load-user-key.pl line 162.
Execution of /opt/vyatta/sbin/vyatta-load-user-key.pl aborted due to compilation errors.
[edit]
vyos@vyos#
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

- https://phabricator.vyos.net/T3865
- https://phabricator.vyos.net/T3506

## Component(s) name

scripts

## Proposed changes

## How to test

## Checklist:

- [x]  I have read the CONTRIBUTING document
- [x]  I have linked this PR to one or more Phabricator Task(s)
- [ ]  I have run the components SMOKETESTS if applicable
- [x]  My commit headlines contain a valid Task id
- [ ]  My change requires a change to the documentation
- [ ]  I have updated the documentation accordingly