### PR TITLE
firewall: T2199: Firewall to version 7 for XML/Python rewrite

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -76,6 +76,7 @@ curver_DATA += cfg-version/conntrack-sync@2
 curver_DATA += cfg-version/ipsec@8
 curver_DATA += cfg-version/openconnect@1
 curver_DATA += cfg-version/https@3
+curver_DATA += cfg-version/firewall@7
 
 cpiop = find  . ! -regex '\(.*~\|.*\.bak\|.*\.swp\|.*\#.*\#\)' -print0 | \
   cpio -0pd


### PR DESCRIPTION
This PR will be required for the upcoming firewall PR on vyos-1x.