### PR TITLE
T4714: Delete unused ipset from filecaps

### DIFF
--- a/sysconf/filecaps
+++ b/sysconf/filecaps
@@ -7,7 +7,6 @@ cap_net_admin=pe	/bin/ip
 # handles /sbin/iptables and /sbin/ip6tables symlink target
 cap_net_admin=pe	/sbin/xtables-legacy-multi
 cap_net_admin=pe	/sbin/xtables-nft-multi
-cap_net_admin=pe	/usr/sbin/ipset
 cap_net_admin=pe	/usr/sbin/conntrack
 cap_net_admin=pe	/usr/sbin/arp
 


### PR DESCRIPTION
We do not use `ipset` anymore
Delete unused ipset from filecaps

https://phabricator.vyos.net/T4714
```
r14:~$ file /usr/sbin/ipset
/usr/sbin/ipset: cannot open `/usr/sbin/ipset' (No such file or directory)
```
Log during build process:
```
05:24:27  Failed to set capabilities on file `/usr/sbin/ipset' (No such file or directory)
```