### PR TITLE
nvme: T4776: Fixed installation to NVME

### DIFF
--- a/scripts/install/install-functions
+++ b/scripts/install/install-functions
@@ -176,7 +176,7 @@ select_drive () {
   # the first grep pattern looks for devices named c0d0, hda, and sda.
   drives=$(cat /proc/partitions | \
            awk '{ if ($4!="name") { print $4 } }' | \
-           egrep "c[0-9]d[0-9]$|[hsv]d[a-z]$|nvme[0-9]n[0-9]|mmcblk[0-9]" | \
+           egrep "c[0-9]d[0-9]$|[hsv]d[a-z]$|nvme[0-9]n[0-9]$|mmcblk[0-9]" | \
            egrep -v "^$" | sort)
 
   #this needs more testing to decide if better than above

--- a/scripts/install/install-get-partition
+++ b/scripts/install/install-get-partition
@@ -571,9 +571,7 @@ delete_partitions () {
   # get the partitions on the drive
   # in the first grep below we add the optional [p] in order to
   # accomdate cciss drives
-  partitions=$(cat /proc/partitions | grep $ldrive[p]*[0-9] \
-               | awk '{ print $4 }' | sed 's/\(.*\)\([0-9]$\)/\2/g' \
-               | grep -v "^$")
+  partitions=$(awk '/'$ldrive'p?[0-9]+$/ { sub(/'$ldrive'/, "") ; print $NF }' /proc/partitions)
   mkdir -p /mnt/tmp
 
   # now for each part, blow it away
@@ -591,6 +589,9 @@ delete_partitions () {
             fi
 	    umount /mnt/tmp
 	fi
+
+	# we must remove possible suffixes from a partition number before passing it to parted
+	lpart="$(echo $lpart | sed 's/[^0-9]//')"
 
 	lecho "Removing partition $lpart on /dev/$ldrive"
 	output=$(parted -s /dev/$ldrive rm $lpart)


### PR DESCRIPTION
* fixed NVME drive names parser
* replaced partition parser to take into account `p` suffixes on NVME partitions