### PR TITLE
T5520: avoid cp from /config during update, after coreutils change

### DIFF
--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -189,9 +189,9 @@ if [ $space_avail -gt $space_needed_configdata ]; then
     resp=$(get_response "Yes" "Yes No Y N")
     if [ "$resp" == 'yes' ] || [ "$resp" == 'y' ]; then
       echo 'Copying current configuration...'
-      ndir=${INST_ROOT}/${VYATTA_NEW_CFG_DIR}
+      ndir=${INST_ROOT}/${VYATTA_CFG_DIR}
       mkdir -p $ndir
-      find $VYATTA_NEW_CFG_DIR -maxdepth 1 -mindepth 1 \
+      find $VYATTA_CFG_DIR -maxdepth 1 -mindepth 1 \
         -exec cp '-a' '{}' "$ndir/" ';'
 
       # Set the upgraded flag
@@ -201,7 +201,7 @@ if [ $space_avail -gt $space_needed_configdata ]; then
       chmod -R 775 $ndir
 
       # Return original permissions for private files in config/auth. T2713
-      rsync -a ${VYATTA_NEW_CFG_DIR}/auth/ ${ndir}/auth/
+      rsync -a ${VYATTA_CFG_DIR}/auth/ ${ndir}/auth/
 
     fi
   done


### PR DESCRIPTION
A change in coreutils package 'cp' in Bookworm + the use of the bind mount /config instead of /opt/vyatta/etc/config in legacy image-tools leads to a possible corruption of config.boot during system update. Further details in task.

Fix now by copying from the ext4 directory /opt/vyatta/etc/config instead of the overlay /config; note that the image-tools rewrite (T4516) does not use the overlay dir during system update.

This should resolve the issue with corruption on system update that has been reported off and on (e.g. T5267).