### PR TITLE
T5593: Further shrink VyOS imagesize, part 1/2

### DIFF
--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -142,18 +142,22 @@ fi
 WORK_DIR="$REL_ROOT/work"
 mkdir -p "$WORK_DIR"
 
-# copy the squashfs image and boot files
+# Copy the squashfs image and boot files
 echo "Copying new release files..."
+
 squash_img=${CD_ROOT}/live/filesystem.squashfs
-boot_dir=${CD_SQUASH_ROOT}/boot
-boot_files=$(find $boot_dir -maxdepth 1 -type f -o -type l 2>/dev/null)
-if [ ! -f "$squash_img" ] || [ -z "$boot_files" ]; then
-  becho 'Cannot find the files. Exiting...'
+boot_dir=${CD_ROOT}/live
+boot_files=$(find ${boot_dir} -maxdepth 1 -type f \( -name "config-*" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz-*" \) 2>/dev/null)
+if [ ! -f "${squash_img}" ] || [ -z "${boot_files}" ]; then
+  echo "Cannot find the squashfs image or boot files. Exiting..."
   exit 1
 fi
-target_squash=$REL_ROOT/$NEWVER.squashfs
-cp -p $squash_img $target_squash >&/dev/null
-cp --no-dereference --preserve=all $boot_files $REL_ROOT/ >&/dev/null
+
+target_squash=${REL_ROOT}/$NEWVER.squashfs
+echo "Copying squash image..."
+cp -p ${squash_img} ${target_squash} >&/dev/null
+echo "Copying kernel and initrd images..."
+cp -dp ${boot_files} ${REL_ROOT}/ >&/dev/null
 
 # mount copied squashfs
 if ! try_mount "-o loop,ro $target_squash $READ_ROOT"; then

--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -147,7 +147,7 @@ echo "Copying new release files..."
 
 squash_img=${CD_ROOT}/live/filesystem.squashfs
 boot_dir=${CD_ROOT}/live
-boot_files=$(find ${boot_dir} -maxdepth 1 -type f \( -name "config-*" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz-*" \) 2>/dev/null)
+boot_files=$(find ${boot_dir} -maxdepth 1 \( -type f \( -name "config-*" -o -name "initrd.img" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz" -o -name "vmlinuz-*" \) -o -type l \( -name "initrd.img" -o -name "vmlinuz" \) \) 2>/dev/null)
 if [ ! -f "${squash_img}" ] || [ -z "${boot_files}" ]; then
   echo "Cannot find the squashfs image or boot files. Exiting..."
   exit 1

--- a/scripts/install/install-image-new
+++ b/scripts/install/install-image-new
@@ -74,12 +74,12 @@ echo "Copying release files..."
 # In such cases, the ISO image has already been mounted by caller.
 squash_img=${CD_ROOT}/live/filesystem.squashfs
 boot_dir=${CD_ROOT}/live
-boot_files=$(find ${boot_dir} -maxdepth 1 -type f \( -name "config-*" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz-*" \) 2>/dev/null)
+boot_files=$(find ${boot_dir} -maxdepth 1 \( -type f \( -name "config-*" -o -name "initrd.img" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz" -o -name "vmlinuz-*" \) -o -type l \( -name "initrd.img" -o -name "vmlinuz" \) \) 2>/dev/null)
 if [ ! -f "${squash_img}" ] || [ -z "${boot_files}" ]; then
   # Maybe installing from a live CD boot?
   squash_img=/lib/live/mount/medium/live/filesystem.squashfs
   boot_dir=/lib/live/mount/medium/live
-  boot_files=$(find ${boot_dir} -maxdepth 1 -type f \( -name "config-*" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz-*" \) 2>/dev/null)
+  boot_files=$(find ${boot_dir} -maxdepth 1 \( -type f \( -name "config-*" -o -name "initrd.img" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz" -o -name "vmlinuz-*" \) -o -type l \( -name "initrd.img" -o -name "vmlinuz" \) \) 2>/dev/null)
   if [ ! -f "${squash_img}" ] || [ -z "${boot_files}" ]; then
     echo "Cannot find the squashfs image or boot files. Exiting..."
     exit 1

--- a/scripts/install/install-image-new
+++ b/scripts/install/install-image-new
@@ -67,28 +67,30 @@ mkdir -p $rw_dir
 work_dir=$WRITE_ROOT/boot/$image_name/work
 mkdir -p $work_dir
 
-echo Copying squashfs image...
-# these are the defaults if installing from a specified ISO image file.
-# in such cases, the ISO image has already been mounted by caller.
+# Copy the squashfs image and boot files
+echo "Copying release files..."
+
+# These are the defaults if installing from a specified ISO image file.
+# In such cases, the ISO image has already been mounted by caller.
 squash_img=${CD_ROOT}/live/filesystem.squashfs
-boot_dir=${CD_SQUASH_ROOT}/boot
-boot_files=$(find $boot_dir -maxdepth 1 -type f -o -type l 2>/dev/null)
-if [ ! -f "$squash_img" ] || [ -z "$boot_files" ]; then
-  # maybe installing from a live CD boot?
+boot_dir=${CD_ROOT}/live
+boot_files=$(find ${boot_dir} -maxdepth 1 -type f \( -name "config-*" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz-*" \) 2>/dev/null)
+if [ ! -f "${squash_img}" ] || [ -z "${boot_files}" ]; then
+  # Maybe installing from a live CD boot?
   squash_img=/lib/live/mount/medium/live/filesystem.squashfs
-  boot_dir=/boot
-  boot_files=$(find $boot_dir -maxdepth 1 -type f -o -type l 2>/dev/null)
-  if [ ! -f "$squash_img" ] || [ -z "$boot_files" ]; then
-    # not a live CD boot either. give up.
-    becho 'Cannot find the squashfs image. Exiting...'
+  boot_dir=/lib/live/mount/medium/live
+  boot_files=$(find ${boot_dir} -maxdepth 1 -type f \( -name "config-*" -o -name "initrd.img-*" -o -name "System.map-*" -o -name "vmlinuz-*" \) 2>/dev/null)
+  if [ ! -f "${squash_img}" ] || [ -z "${boot_files}" ]; then
+    echo "Cannot find the squashfs image or boot files. Exiting..."
     exit 1
   fi
 fi
 
-target_squash=$WRITE_ROOT/boot/$image_name/$version.squashfs
-cp -p $squash_img $target_squash
-echo Copying kernel and initrd images...
-cp -dp $boot_files $WRITE_ROOT/boot/$image_name/
+target_squash=${WRITE_ROOT}/boot/$image_name/$version.squashfs
+echo "Copying squash image..."
+cp -p ${squash_img} ${target_squash} >&/dev/null
+echo "Copying kernel and initrd images..."
+cp -dp ${boot_files} ${WRITE_ROOT}/boot/$image_name/ >&/dev/null
 
 # create persistence.conf file
 echo "/ union" > $WRITE_ROOT/persistence.conf


### PR DESCRIPTION
Further shrink VyOS imagesize (ISO) by moving Linux kernel-files out of the filesystem.squashfs and into the live-directory of the ISO.

Note! There is a part 2/2 of this for vyos-build that must be merged at the same time.

For this to work following files have been modified:

* scripts/install/install-image-new
So the Linux-kernel files are copied to the persistent boot-directory during install.

* scripts/install/install-image-existing
So the Linux-kernel files are copied to the persistent boot-directory during upgrade.

Smoketest results:

```
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
DEBUG - EXITCODE:0
 INFO - Smoketest finished successfully!
 INFO - Powering off system
DEBUG - vyos@vyos:~$ poweroff now
 INFO - Shutting down virtual machine
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - Waiting for shutdown...
DEBUG - poweroff now
 INFO - VM is shut down!
 INFO - Cleaning up
 INFO - Removing disk file: testinstall-20230926-233250-071e.img
```

For more information see task:

* https://vyos.dev/T5593