### PR TITLE
boot: T5739: Fixed password recovery

### DIFF
--- a/scripts/standalone_root_pw_reset
+++ b/scripts/standalone_root_pw_reset
@@ -28,7 +28,7 @@ ADMIN=vyos
 
 set_encrypted_password() {
     sed -i \
-       -e "/ user $1 {/,/}/s/encrypted-password .*\$/encrypted-password $2/" $3
+       -e "/ user $1 {/,/encrypted-password/s/encrypted-password .*\$/encrypted-password \"$2\"/" $3
 }
 
 


### PR DESCRIPTION
This change fixes a filter used for `sed` during password reset in the `set_encrypted_password()` function.

Old logic: search between `user username {` and the first line with `}` does not work for users with extra options in config, like public keys.

New logic: search between `user username {` and the first line with `encrypted-password` which should cover all possible combinations, except situations when a password is not presented in a configuration file.