### PR TITLE
T5826: debian: add dmidecode as an explict depdency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,8 @@ Depends:  adduser,
  grub-efi-arm64-bin [arm64],
  dosfstools,
  gdisk,
- vyatta-biosdevname
+ vyatta-biosdevname,
+ dmidecode
 Pre-Depends: bash-completion
 Suggests: util-linux (>= 2.13-5),
  net-tools,


### PR DESCRIPTION
On non-x86 systems, dmidecode may not be specified as an explicit dependency of the packages that recommend it (like laptop-detect and virt-what). Ensure it is installed regardless of target architecture.


Related vyos-1x pull request: https://github.com/vyos/vyos-1x/pull/2631
As there are references to dmidecode in this package as well, I figure it should also be added here for good measure 

https://github.com/vyos/vyatta-cfg-system/blob/16e9d71ffbe4153aaaa23b924b2ebf8ec29715db/scripts/install/install-postinst-new#L213
