### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,3 @@ Mirror twin: `VyOS-Networks/vyatta-cfg-system` (drifted; gen-1 mirror pipeline n
 - Do not add features here — extend `vyos-1x` instead. Acceptable changes are CVE/security backports for LTS trains.
 - Preserve the deprecation notice in `README`; future work should not silently revive this package.
 - The workflow set diverges from the modern `vyos/.github@current` reusable model; do not rewire without a coordinated update to the LTS branches.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyatta-cfg-system`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544861). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+## Project purpose
+Legacy Vyatta system-level configuration scripts. **Deprecated**: per the in-repo `README`, "this package is deprecated and all it's content was rewritten" — replaced by `vyos/vyos-1x`. Retained only on LTS trains (sagitta/equuleus) for compatibility.
+
+## Tech stack
+- Shell + Perl + minor C/C++. Autotools (`configure.ac`, `Makefile.am`).
+- Build deps (`debian/control`): `debhelper (>= 5)`, `autotools-dev`, `autoconf`, `automake`, `cpio`.
+- Debian packaging via `dpkg-buildpackage`.
+
+## Build / test / run
+```
+autoreconf -i && ./configure && make
+dpkg-buildpackage -uc -us -tc -b
+```
+No standalone test harness.
+
+## Repository layout
+- `scripts/` — install-time and op-mode helper scripts.
+- `sysconf/` — system configuration assets shipped to `/etc`.
+- `debian/` — packaging.
+- `README` — deprecation notice pointing at `vyos-1x`.
+
+## Cross-repo context
+Historical sibling of `vyos/vyatta-cfg`. Functionality migrated into `vyos/vyos-1x` (`src/conf_mode/`, `src/op_mode/`, `python/vyos/`). Still pulled into LTS ISO builds by `vyos/vyos-build` where required.
+
+## Conventions
+- Commit/PR title: `component: T12345: description`. Phorge IDs at https://vyos.dev.
+- Reusable workflows: this repo carries an older workflow set (`pull-request-management.yml`, `mergifyio_backport.yml`, `pull-request-message-check.yml`, etc.) that predates the consolidation under `vyos/.github`. Edit only if the LTS train still needs them.
+- Default branch is `current` for the canonical history; LTS branches `sagitta`/`equuleus` are where active backports land.
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyatta-cfg-system` (drifted; gen-1 mirror pipeline not confirmed live for this repo). Treat the `vyos/*` side as canonical.
+
+## Notes for future contributors
+- Do not add features here — extend `vyos-1x` instead. Acceptable changes are CVE/security backports for LTS trains.
+- Preserve the deprecation notice in `README`; future work should not silently revive this package.
+- The workflow set diverges from the modern `vyos/.github@current` reusable model; do not rewire without a coordinated update to the LTS branches.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyatta-cfg-system`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818544861). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
