### PR TITLE
T8943: migrate branch refs current->rolling (rollout 1c)

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [current]
+    branches: [rolling]
   workflow_dispatch:
     inputs:
       sync_branch:

--- a/.github/workflows/pull-request-labels.yml
+++ b/.github/workflows/pull-request-labels.yml
@@ -4,7 +4,7 @@ name: Add pull request labels
 on:
   pull_request_target:
     branches:
-      - current
+      - rolling
       - crux
       - equuleus
       - sagitta

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -4,7 +4,7 @@ name: Build Pull Request Package
 on:
   pull_request:
     branches:
-      - current
+      - rolling
       - crux
       - equuleus
 

--- a/.github/workflows/pull-request-message-check.yml
+++ b/.github/workflows/pull-request-message-check.yml
@@ -4,7 +4,7 @@ name: Check pull request message format
 on:
   pull_request:
     branches:
-      - current
+      - rolling
       - crux
       - equuleus
 


### PR DESCRIPTION
Rollout 1c reference migration. Own trunk refs current->rolling; action-ref to vyos/.github -> production; HIGH-producer pins already swept. Tracking: T8943