### PR TITLE
T8943: fix missed trigger branch current->rolling (rollout 1c)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "current", crux, equuleus ]
+    branches: [ "rolling", crux, equuleus ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "current" ]
+    branches: [ "rolling" ]
   schedule:
     - cron: '22 10 * * 0'
 


### PR DESCRIPTION
Rollout 1c follow-up: a self-trunk trigger branch ref was missed in the batch ref-edit; migrating current->rolling so the workflow fires on the renamed default. Tracking: T8943