### PR TITLE
ci: T8966: add product T-ID title/commit check (opt-in relocation)

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,3 +2,22 @@
 extends: mergify
 merge_protections_settings:
   reporting_method: check-runs
+
+pull_request_rules:
+  - name: Flag product T-ID format violation in PR title or commit messages
+    description: >
+      Product-repo convention: PR title and every commit's first line must
+      match `T<digits>: <text>` (optional `scope: ` prefix). Relocated from
+      the central config (T8966) so the T-ID convention is opt-in per product
+      repo. Name is intentionally distinct from any central rule name so this
+      stays additive (not an `extends:` override).
+    conditions:
+      - '-closed'
+      - '-merged'
+      - or:
+          - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'
+          - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
+    actions:
+      label:
+        toggle:
+          - invalid-task-id


### PR DESCRIPTION
Relocates the central strict T-ID title/commit check into this product repo as an opt-in rule (toggles `invalid-task-id`), per T8966. Additive — does not change any existing rule.

🤖 Generated by [robots](https://vyos.io)