### PR TITLE
ci: T8490: fix typos in comments and install/snmp messages

### DIFF
--- a/scripts/install/install-get-partition
+++ b/scripts/install/install-get-partition
@@ -235,7 +235,7 @@ check_for_new_raid () {
   for drive in $drives; do
     create_partitions "$drive" $root_size "no"
     if [ -d /sys/firmware/efi ]; then
-        #EFI moves the data parition on RAID to 3
+        #EFI moves the data partition on RAID to 3
         data_dev=3
         echo "Create data partition: ${data_dev} on /dev/${drive}"
     else
@@ -576,7 +576,7 @@ delete_partitions () {
 
   # get the partitions on the drive
   # in the first grep below we add the optional [p] in order to
-  # accomdate cciss drives
+  # accommodate cciss drives
   partitions=$(awk '/'$ldrive'p?[0-9]+$/ { sub(/'$ldrive'/, "") ; print $NF }' /proc/partitions)
   mkdir -p /mnt/tmp
 
@@ -736,7 +736,7 @@ setup_method_manual() {
   parted=$1
 
   echo "The VyOS install needs a minimum ${ROOT_MIN}MB root"
-  echo "with partiton type 83 (Linux)."
+  echo "with partition type 83 (Linux)."
   echo -e "\n\n"
 
   # if this is parted, let the user create the partitions
@@ -841,7 +841,7 @@ setup_method_auto () {
     root_part_size=$(echo "$response" | sed 's/[^0-9]//g')
     if [ $root_part_size -lt $ROOT_MIN ] \
         || [ $root_part_size -gt $size ]; then
-      echo "Root partion must be between $ROOT_MIN"MB" and $size"MB""
+      echo "Root partition must be between $ROOT_MIN"MB" and $size"MB""
       echo
       root_part_size=0
     fi

--- a/scripts/install/install-image-existing
+++ b/scripts/install/install-image-existing
@@ -43,7 +43,7 @@ fi
 
 # On image-installed systems, the image name can be found as the
 # directory under "/boot" on the path to the running kernel on the
-# boot line. On non-image-installed systems, this yelds the
+# boot line. On non-image-installed systems, this yields the
 # name of the kernel image file.
 CURVER=`awk '{print $1}' /proc/cmdline`
 CURVER=${CURVER#BOOT_IMAGE=/boot/}
@@ -283,7 +283,7 @@ if ! try_unmount "--read-only $INST_ROOT $READ_ROOT"; then
   failure_exit 'Failed to unmount new squashfs image.'
 fi
 
-# sync underlaying filesystems
+# sync underlying filesystems
 sync
 
 logger -p local3.warning -t "SystemImage" "System Image $NEWNAME has been added and made the default boot image"

--- a/scripts/snmp/if-mib-alias
+++ b/scripts/snmp/if-mib-alias
@@ -107,7 +107,7 @@ sub set_oid {
     my $ifname = ifindextoname($ifindex);
     if ($ifname) {
 	system("ip li set $ifname alias '$value' >/dev/null 2>&1");
-	print "not-writeable\n"	if ($? != 0);
+	print "not-writable\n"	if ($? != 0);
     }
 }
 

--- a/scripts/vyatta-grub-setup
+++ b/scripts/vyatta-grub-setup
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Module: grup-setup
+# Module: grub-setup
 #
 # **** License ****
 # This program is free software; you can redistribute it and/or modify
@@ -82,7 +82,7 @@ usb_console="console=tty0 console=ttyUSB0,115200"
 # See kernel Documentation/fb/vesafb.txt for resolution constants
 #VGA_LOGO="vga=785"
 
-# Disable SELinux when doing maintance operations
+# Disable SELinux when doing maintenance operations
 NOSELINUX="selinux=0"
 
 # get list of kernels, except Xen


### PR DESCRIPTION
## What
Comment- and message-string typo fixes (no code identifiers changed):
- `scripts/install/install-get-partition`: `parition`/`partiton`/`partion` → `partition`; `accomdate` → `accommodate`
- `scripts/install/install-image-existing`: `yelds` → `yields`; `underlaying` → `underlying`
- `scripts/snmp/if-mib-alias`: `"not-writeable"` → `"not-writable"`
- `scripts/vyatta-grub-setup`: `"grup-setup"` → `"grub-setup"` (GRUB bootloader, not "group"); `maintance` → `maintenance`

## Why
Clears this repo's typos-check hits ahead of the T8490 ruleset pilot active flip. Only the misspelled tokens were changed — the many correctly-spelled `partition` occurrences in the install script are untouched.

Phase-0 CodeRabbit: no findings. Tracking: Phorge T8490 · Jira [IS-555](https://vyos.atlassian.net/browse/IS-555) (typos-ruleset pilot, Phase 2 Task 2.4).

🤖 Generated by [robots](https://vyos.io)


[IS-555]: https://vyos.atlassian.net/browse/IS-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ