### PR TITLE
T9164: accept NOS-/VD- Jira keys in task-id check; pin NOS in coderabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,4 +26,5 @@ knowledge_base:
     # source where it is not.
     usage: auto
     project_keys:
+      - NOS
       - VD

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,10 +7,12 @@ pull_request_rules:
   - name: Flag product T-ID format violation in PR title or commit messages
     description: >
       Product-repo convention: PR title and every commit's first line must
-      match `T<digits>: <text>` (optional `scope: ` prefix). Relocated from
-      the central config (T8966) so the T-ID convention is opt-in per product
-      repo. Name is intentionally distinct from any central rule name so this
-      stays additive (not an `extends:` override).
+      match a `T<digits>:`, `NOS-<digits>:` or legacy `VD-<digits>:` task key
+      followed by text (optional `scope: ` prefix). NOS is the renamed VD Jira
+      project (2026-07). Relocated from the central config (T8966) so the T-ID
+      convention is opt-in per product repo. Name is intentionally distinct
+      from any central rule name so this stays additive (not an `extends:`
+      override).
     conditions:
       - '-closed'
       - '-merged'
@@ -18,10 +20,10 @@ pull_request_rules:
       - 'author!=copilot-swe-agent'
       - 'author!=vyosbot'
       - or:
-          - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'
+          - '-title~=^(([a-zA-Z0-9\-_.]+:[ ])?)(T[0-9]+|NOS-[0-9]+|VD-[0-9]+):[ ]+[^\s]+.*'
           - and:
               - 'label!=legacy'
-              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
+              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:[ ])?)(T[0-9]+|NOS-[0-9]+|VD-[0-9]+):[ ]+[^\s]+).*'
     actions:
       label:
         toggle:


### PR DESCRIPTION
Fleet replication of the adversarially-reviewed canary [vyos/vyos-1x#5379](https://github.com/vyos/vyos-1x/pull/5379) for the VD→NOS Jira project rename ([T9164](https://vyos.dev/T9164)). `.github/mergify.yml` — the `invalid-task-id` rule's two regexes and its `description` now accept `T<digits>:`, `NOS-<digits>:` and legacy `VD-<digits>:` keys; the rule **name** is byte-identical, so this stays additive rather than an `extends:` override. `.coderabbit.yaml` — `knowledge_base.jira.project_keys` pins `NOS` ahead of the retained legacy `VD`. Byte-identical template application — `skip-adversarial` per the documented escape hatch (2 findings were found and fixed on the canary; regexes ship tightened: ASCII digits + literal-space separators).

Phase 0 (local CodeRabbit CLI, `--base origin/rolling`): 1 finding (major, `.coderabbit.yaml`) — reviewed and **declined**, no code change.

> Remove NOS from the project key configuration in `.coderabbit.yaml`, leaving VD as the active project key until the T9164 decision is approved.

That is a request to revert the change this PR exists to make, so it is out of scope by construction:

- **The rename is already decided and shipped**, not pending. `VD` was renamed to `NOS` in the tracker (2026-07); the canary [vyos/vyos-1x#5379](https://github.com/vyos/vyos-1x/pull/5379) landed the same edit after adversarial review, and this PR is its fleet replication.
- **Nothing is lost by keeping both.** The change is purely additive — `project_keys` goes from `[VD]` to `[NOS, VD]`. Legacy `VD-` markers on historical branches, backports and old commits keep resolving; dropping `NOS` would only leave the new, live key unresolvable.
- **Approval is not expressible in this file, and is not bypassed.** This PR ships as a **draft** with no auto-merge and no ready-flip; the merge decision sits with a maintainer. CodeRabbit is inferring a merge-gating policy from the T9164 context rather than flagging a defect in the diff.

Template-scope pushback, consistent with the canary and the rest of this sweep. Correction welcome if a maintainer reads it differently.

Advances: IS-640

🤖 Generated by [robots](https://vyos.io)

